### PR TITLE
chore: rename plugin and move to semantic-release org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,21 @@
-# **sr-commit-analyzer**
+# **commit-analyzer**
 
 Customizable commit-analyzer plugin for [semantic-release](https://github.com/semantic-release/semantic-release) based on [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
 
-[![npm](https://img.shields.io/npm/v/sr-commit-analyzer.svg)](https://www.npmjs.com/package/sr-commit-analyzer)
-[![npm](https://img.shields.io/npm/dt/sr-commit-analyzer.svg)](https://www.npmjs.com/package/sr-commit-analyzer)
-[![Greenkeeper badge](https://badges.greenkeeper.io/vanduynslagerp/sr-commit-analyzer.svg)](https://greenkeeper.io/)
-[![license](https://img.shields.io/github/license/vanduynslagerp/sr-commit-analyzer.svg)](https://github.com/vanduynslagerp/sr-commit-analyzer/blob/master/LICENSE)
+[![npm](https://img.shields.io/npm/v/@semantic-release/commit-analyzer.svg)](https://www.npmjs.com/package/@semantic-release/commit-analyzer)
+[![npm](https://img.shields.io/npm/dt/@semantic-release/commit-analyzer.svg)](https://www.npmjs.com/package/@semantic-release/commit-analyzer)
+[![Greenkeeper badge](https://badges.greenkeeper.io/semantic-release/commit-analyzer.svg)](https://greenkeeper.io/)
+[![license](https://img.shields.io/github/license/semantic-release/commit-analyzer.svg)](https://github.com/semantic-release/commit-analyzer/blob/master/LICENSE)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
-[![Travis](https://img.shields.io/travis/vanduynslagerp/sr-commit-analyzer.svg)](https://travis-ci.org/vanduynslagerp/sr-commit-analyzer)
-[![Codecov](https://img.shields.io/codecov/c/github/vanduynslagerp/sr-commit-analyzer.svg)](https://codecov.io/gh/vanduynslagerp/sr-commit-analyzer)
-
-## Install
-```bash
-npm install --save-dev semantic-release sr-commit-analyzer
-```
-
-Set the `analyzeCommits` plugin for `semantic-release` in `package.json`. See [semantic-release plugins](https://github.com/semantic-release/semantic-release#plugins).
-```json
-{
-  "release": {
-    "analyzeCommits": "sr-commit-analyzer"
-  }
-}
-```
+[![Travis](https://img.shields.io/travis/semantic-release/commit-analyzer.svg)](https://travis-ci.org/semantic-release/commit-analyzer)
+[![Codecov](https://img.shields.io/codecov/c/github/semantic-release/commit-analyzer.svg)](https://codecov.io/gh/semantic-release/commit-analyzer)
 
 ## Options
 
-By default `sr-commit-analyzer` uses the `angular` format described in [Angular convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/convention.md).
+By default `commit-analyzer` uses the `angular` format described in [Angular convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/convention.md).
 
 Additionnal options can be set within the plugin definition in `package.json` to use a different commit format and to customize it:
 
@@ -37,7 +23,6 @@ Additionnal options can be set within the plugin definition in `package.json` to
 {
   "release": {
     "analyzeCommits": {
-      "path": "sr-commit-analyzer",
       "preset": "angular",
       "releaseRules": [
         {"type": "docs", "scope":"README", "release": "patch"},
@@ -69,7 +54,6 @@ This is an `Array` of rule objects. A rule object has a `release` property and 1
 {
   "release": {
     "analyzeCommits": {
-      "path": "sr-commit-analyzer",
       "preset": "angular",
       "releaseRules": [
         {"type": "docs", "scope": "README", "release": "patch"},
@@ -129,7 +113,6 @@ For example with `eslint` preset:
 {
   "release": {
     "analyzeCommits": {
-      "path": "sr-commit-analyzer",
       "preset": "eslint",
       "releaseRules": [
         {"tag": "Docs", "message":"/README/", "release": "patch"},
@@ -155,7 +138,6 @@ With this configuration:
 {
   "release": {
     "analyzeCommits": {
-      "path": "sr-commit-analyzer",
       "preset": "angular",
       "releaseRules": "./config/release-rules.js"
     }
@@ -180,7 +162,6 @@ The following example uses [Angular convention](https://github.com/conventional-
 {
   "release": {
     "analyzeCommits": {
-      "path": "sr-commit-analyzer",
       "preset": "angular",
       "parserOpts": {
         "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"],

--- a/lib/load/release-rules.js
+++ b/lib/load/release-rules.js
@@ -19,7 +19,7 @@ module.exports = ({releaseRules}) => {
 
     if (!Array.isArray(loadedReleaseRules)) {
       throw new SemanticReleaseError(
-        'Error in sr-commit-analyzer configuration: "releaseRules" must be an array of rules',
+        'Error in commit-analyzer configuration: "releaseRules" must be an array of rules',
         'EINVALIDCONFIG'
       );
     }
@@ -27,7 +27,7 @@ module.exports = ({releaseRules}) => {
     loadedReleaseRules.forEach(rule => {
       if (RELEASE_TYPES.indexOf(rule.release) === -1) {
         throw new SemanticReleaseError(
-          `Error in sr-commit-analyzer configuration: "${rule.release}" is not a valid release type. Valid values are: ${JSON.stringify(
+          `Error in commit-analyzer configuration: "${rule.release}" is not a valid release type. Valid values are: ${JSON.stringify(
             RELEASE_TYPES
           )}`,
           'EINVALIDRELEASE'

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "sr-commit-analyzer",
+  "name": "@semantic-release/commit-analyzer",
   "description": "Customizable commit-analyzer plugin for semantic-release",
   "version": "0.0.0-development",
   "author": "Pierre Vanduynslager",
   "bugs": {
-    "url": "https://github.com/vanduynslagerp/sr-commit-analyzer/issues"
+    "url": "https://github.com/semantic-release/commit-analyzer/issues"
   },
   "config": {
     "commitizen": {
@@ -44,7 +44,6 @@
     "prettier": "^1.5.3",
     "rimraf": "^2.6.1",
     "semantic-release": "^8.0.0",
-    "sr-release-notes-generator": "^1.1.1",
     "tempy": "^0.2.0"
   },
   "engines": {
@@ -73,7 +72,7 @@
   "files": [
     "lib"
   ],
-  "homepage": "https://github.com/vanduynslagerp/sr-commit-analyzer#readme",
+  "homepage": "https://github.com/semantic-release/commit-analyzer#readme",
   "keywords": [
     "changelog",
     "commit-analyzer",
@@ -115,14 +114,11 @@
   "release": {
     "analyzeCommits": {
       "path": "./lib/index.js"
-    },
-    "generateNotes": {
-      "path": "sr-release-notes-generator"
     }
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/vanduynslagerp/sr-commit-analyzer.git"
+    "url": "https://github.com/semantic-release/commit-analyzer.git"
   },
   "scripts": {
     "clean": "rimraf coverage && rimraf .nyc_output",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -140,7 +140,7 @@ test('Throw "SemanticReleaseError" if "preset" doesn`t exist', async t => {
 test('Throw "SemanticReleaseError" if "releaseRules" is not an Array or a String', async t => {
   const error = await t.throws(
     pify(commitAnalyzer)({releaseRules: {}}, {}),
-    /Error in sr-commit-analyzer configuration: "releaseRules" must be an array of rules/
+    /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -150,7 +150,7 @@ test('Throw "SemanticReleaseError" if "releaseRules" is not an Array or a String
 test('Throw "SemanticReleaseError" if "releaseRules" option reference a requierable module that is not an Array or a String', async t => {
   const error = await t.throws(
     pify(commitAnalyzer)({releaseRules: './test/fixtures/release-rules-invalid'}, {}),
-    /Error in sr-commit-analyzer configuration: "releaseRules" must be an array of rules/
+    /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -171,7 +171,7 @@ test('Throw "SemanticReleaseError" if "config" doesn`t exist', async t => {
 test('Throw "SemanticReleaseError" if "releaseRules" reference invalid commit type', async t => {
   const error = await t.throws(
     pify(commitAnalyzer)({preset: 'eslint', releaseRules: [{tag: 'Update', release: 'invalid'}]}, {}),
-    /Error in sr-commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
+    /Error in commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
   );
 
   t.is(error.code, 'EINVALIDRELEASE');

--- a/test/load-release-rules.test.js
+++ b/test/load-release-rules.test.js
@@ -24,7 +24,7 @@ test('Return undefined if "releaseRules" not set', t => {
 test('Throw "SemanticReleaseError" if "releaseRules" reference invalid commit type', t => {
   const error = t.throws(
     () => loadReleaseRules({releaseRules: [{tag: 'Update', release: 'invalid'}]}),
-    /Error in sr-commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
+    /Error in commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
   );
 
   t.is(error.code, 'EINVALIDRELEASE');
@@ -34,7 +34,7 @@ test('Throw "SemanticReleaseError" if "releaseRules" reference invalid commit ty
 test('Throw "SemanticReleaseError" if "releaseRules" is not an Array or a String', t => {
   const error = t.throws(
     () => loadReleaseRules({releaseRules: {}}, {}),
-    /Error in sr-commit-analyzer configuration: "releaseRules" must be an array of rules/
+    /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -44,7 +44,7 @@ test('Throw "SemanticReleaseError" if "releaseRules" is not an Array or a String
 test('Throw "SemanticReleaseError" if "releaseRules" option reference a requierable module that is not an Array or a String', t => {
   const error = t.throws(
     () => loadReleaseRules({releaseRules: './test/fixtures/release-rules-invalid'}),
-    /Error in sr-commit-analyzer configuration: "releaseRules" must be an array of rules/
+    /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 
   t.true(error instanceof SemanticReleaseError);


### PR DESCRIPTION
- [x]  rename https://github.com/semantic-release/commit-analyzer to https://github.com/semantic-release/commit-analyzer-v2 and archive it => @gr2m 
- [x] rename this repository to commit-analyzer and move it to the semantic-release organization => @vanduynslagerp
- [x] Merge this PR to change the package name to `@semantic-release/rcommit-analyzer` => @gr2m 
- [x] manually release @semantic-release/commit-analyzer@3.0.0, create the git tag and release and add all changelogs => @gr2m 
- [x] deprecate the `sr-commit-analyzer` package and point it to ` @semantic-release/commit-analyzer` => @vanduynslagerp
- [x] setup the integrations in the semantic-release/commit-analyzer repository => @vanduynslagerp + @gr2m (Greenkeeper)