### PR TITLE
Set minimum node version to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tempy": "^0.2.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=4"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Avoid `yarn` to fail when installing on node `<8`.
The library will never have to run on `node` `<8` as `semantic-release` will call it only on when running on `node` `>=8`.

See semantic-release/semantic-release#433