### PR TITLE
Update semantic-release to version 9.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "nyc": "^11.1.0",
     "prettier": "^1.7.2",
     "rimraf": "^2.6.1",
-    "semantic-release": "^8.0.0",
+    "semantic-release": "^9.0.2",
     "sinon": "^4.0.2"
   },
   "engines": {
@@ -108,7 +108,7 @@
     "codecov": "codecov -f coverage/coverage-final.json",
     "lint": "eslint lib test",
     "pretest": "npm run clean && npm run lint",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "semantic-release": "semantic-release",
     "test": "nyc ava -v"
   }
 }


### PR DESCRIPTION
As the plugin use itself to release, it requires semantic-release 9.0.0