### PR TITLE
Handle squash merges

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ async function commitAnalyzer(pluginConfig, {commits, logger}) {
 
   unsquashedCommits.every(rawCommit => {
     const commit = parser(rawCommit.message, config);
-    logger.log(`Analyzing commit: %s`, rawCommit.message);
+    const squashed = rawCommit.squash ? 'squashed ' : '';
+    logger.log(`Analyzing ${squashed}commit: %s`, rawCommit.message);
     let commitReleaseType;
 
     // Determine release type based on custom releaseRules

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const analyzeCommit = require('./lib/analyze-commit');
 const compareReleaseTypes = require('./lib/compare-release-types');
 const RELEASE_TYPES = require('./lib/default-release-types');
 const DEFAULT_RELEASE_RULES = require('./lib/default-release-rules');
-
+const parseSquashMerge = require('./lib/squash-merge-parser.js');
 /**
  * Determine the type of release to create based on a list of commits.
  *
@@ -25,7 +25,17 @@ async function commitAnalyzer(pluginConfig, {commits, logger}) {
   const config = await loadParserConfig(pluginConfig);
   let releaseType = null;
 
-  commits.every(rawCommit => {
+  const unsquashedCommits = commits.reduce((commits, commit) => {
+    const unsquashed = parseSquashMerge(commit);
+    if (unsquashed) {
+      commits.push(...unsquashed);
+    } else {
+      commits.push(commit);
+    }
+    return commits;
+  }, []);
+
+  unsquashedCommits.every(rawCommit => {
     const commit = parser(rawCommit.message, config);
     logger.log(`Analyzing commit: %s`, rawCommit.message);
     let commitReleaseType;
@@ -59,7 +69,7 @@ async function commitAnalyzer(pluginConfig, {commits, logger}) {
     }
     return true;
   });
-  logger.log('Analysis of %s commits complete: %s release', commits.length, releaseType || 'no');
+  logger.log('Analysis of %s commits complete: %s release', unsquashedCommits.length, releaseType || 'no');
 
   return releaseType;
 }

--- a/lib/squash-merge-parser.js
+++ b/lib/squash-merge-parser.js
@@ -1,0 +1,81 @@
+const SQUASH_MERGE_COMMIT_HEADER = /^commit [a-f0-9]*$/;
+const SQUASH_MERGE_AUTHOR_HEADER = /^Author: .*$/;
+const SQUASH_MERGE_DATE_HEADER = /^Date: .*$/;
+const SQUASH_MERGE_INDENT = '    ';
+
+function findNextSquashCommit(lines, currentLine) {
+  while (lines[currentLine] === '' && currentLine < lines.length) {
+    currentLine++;
+  }
+
+  if (currentLine >= lines.length) {
+    return {result: 'done'};
+  }
+
+  const commit = SQUASH_MERGE_COMMIT_HEADER.exec(lines[currentLine++]);
+  const author = SQUASH_MERGE_AUTHOR_HEADER.exec(lines[currentLine++]);
+  const date = SQUASH_MERGE_DATE_HEADER.exec(lines[currentLine++]);
+  if (!(commit && author && date)) {
+    return {result: 'error'};
+  }
+
+  let message = '';
+  while (
+    currentLine < lines.length &&
+    (lines[currentLine] === '' || lines[currentLine].startsWith(SQUASH_MERGE_INDENT))
+  ) {
+    message += `${lines[currentLine].slice(SQUASH_MERGE_INDENT.length)}\n`;
+    currentLine++;
+  }
+
+  return {result: 'found', message: message.trim(), currentLine};
+}
+
+/**
+ * A squash merge may have several commits masquerading as one.  This splits up
+ * the commit message into an array of commits.  If the commit is not a squash
+ * merge, returns `undefined`.
+ *
+ * @param {Object} commit - The commit.
+ * @returns {Array | undefiend} - Array of commits, or `undefined`
+ *   if this is not a squash merge.
+ */
+module.exports = function(commit) {
+  let answer;
+
+  const lines = commit.message.split(/\r|\n/);
+  if (lines[0] === 'Squashed commit of the following:') {
+    debugger;
+    let success = true;
+    const commits = [];
+
+    let currentLine = 1;
+    while (currentLine < lines.length) {
+      const nextCommit = findNextSquashCommit(lines, currentLine);
+      switch (nextCommit.result) {
+        case 'found':
+          commits.push({
+            message: nextCommit.message,
+            squash: true
+          });
+          ({currentLine} = nextCommit);
+          break;
+        case 'done':
+          currentLine = lines.length;
+          break;
+        case 'error':
+          success = false;
+          currentLine = lines.length;
+          break;
+        default:
+          throw new Error(`Unhandled case ${nextCommit.result}`);
+      }
+    }
+
+    if (success) {
+      answer = commits;
+    }
+  }
+
+  return answer;
+};

--- a/lib/squash-merge-parser.js
+++ b/lib/squash-merge-parser.js
@@ -8,10 +8,6 @@ function findNextSquashCommit(lines, currentLine) {
     currentLine++;
   }
 
-  if (currentLine >= lines.length) {
-    return {result: 'done'};
-  }
-
   const commit = SQUASH_MERGE_COMMIT_HEADER.exec(lines[currentLine++]);
   const author = SQUASH_MERGE_AUTHOR_HEADER.exec(lines[currentLine++]);
   const date = SQUASH_MERGE_DATE_HEADER.exec(lines[currentLine++]);
@@ -45,7 +41,6 @@ module.exports = function(commit) {
 
   const lines = commit.message.split(/\r|\n/);
   if (lines[0] === 'Squashed commit of the following:') {
-    debugger;
     let success = true;
     const commits = [];
 
@@ -56,17 +51,15 @@ module.exports = function(commit) {
         case 'found':
           commits.push({
             message: nextCommit.message,
-            squash: true
+            squash: true,
           });
           ({currentLine} = nextCommit);
-          break;
-        case 'done':
-          currentLine = lines.length;
           break;
         case 'error':
           success = false;
           currentLine = lines.length;
           break;
+        /* istanbul ignore next */
         default:
           throw new Error(`Unhandled case ${nextCommit.result}`);
       }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -20,42 +20,6 @@ test('Parse with "conventional-changelog-angular" by default', async t => {
   t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'minor'));
 });
 
-test('Correctly handle squash merges', async t => {
-  const message =
-    'Squashed commit of the following:\n' +
-    '\n' +
-    'commit 06cfb67026eecec2ad54fd39fc50cba9080d383c\n' +
-    'Author: Jason Walton <fakeaddress@fake.com>\n' +
-    'Date:   Thu May 17 11:21:50 2018 -0400\n' +
-    '\n' +
-    '    fix: More fixes\n' +
-    '\n' +
-    '    Blah blah blah.\n' +
-    '\n' +
-    '    Fixes #20\n' +
-    '\n' +
-    'commit b894885ae467975226e81080a35625d247796960\n' +
-    'Author: Jason Walton <fakeaddress@fake.com>\n' +
-    'Date:   Thu May 17 11:13:25 2018 -0400\n' +
-    '\n' +
-    '    feat: Add moar features!\n';
-
-  const splitCommits = [
-    'fix: More fixes\n\nBlah blah blah.\n\nFixes #20',
-    'feat: Add moar features!'
-  ];
-
-  const commits = [{message}];
-  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
-
-  t.is(releaseType, 'minor');
-  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[0]));
-  t.true(t.context.log.calledWith('The release type for the commit is %s', 'patch'));
-  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[1]));
-  t.true(t.context.log.calledWith('The release type for the commit is %s', 'minor'));
-  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'minor'));
-});
-
 test('Accept "preset" option', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
   const releaseType = await commitAnalyzer({preset: 'eslint'}, {commits, logger: t.context.logger});
@@ -276,4 +240,123 @@ test('Throw error if "releaseRules" reference invalid commit type', async t => {
 test('Re-Throw error from "conventional-changelog-parser"', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
   await t.throws(commitAnalyzer({parserOpts: {headerPattern: '\\'}}, {commits, logger: t.context.logger}));
+});
+
+test('Correctly handle squash merges', async t => {
+  const message =
+    'Squashed commit of the following:\n' +
+    '\n' +
+    'commit 06cfb67026eecec2ad54fd39fc50cba9080d383c\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:21:50 2018 -0400\n' +
+    '\n' +
+    '    fix: More fixes\n' +
+    '\n' +
+    '    Blah blah blah.\n' +
+    '\n' +
+    '    Fixes #20\n' +
+    '\n' +
+    'commit b894885ae467975226e81080a35625d247796960\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:13:25 2018 -0400\n' +
+    '\n' +
+    '    feat: Add moar features!\n';
+
+  const splitCommits = ['fix: More fixes\n\nBlah blah blah.\n\nFixes #20', 'feat: Add moar features!'];
+
+  const commits = [{message}];
+  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+
+  t.is(releaseType, 'minor');
+  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[0]));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'patch'));
+  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[1]));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'minor'));
+  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'minor'));
+});
+
+test('Treat modified squash merges like regular commmit messages', async t => {
+  const message =
+    'fix: This is only a fix.\n' +
+    '\n' +
+    'commit 06cfb67026eecec2ad54fd39fc50cba9080d383c\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:21:50 2018 -0400\n' +
+    '\n' +
+    '    fix: More fixes\n' +
+    '\n' +
+    '    Blah blah blah.\n' +
+    '\n' +
+    '    Fixes #20\n' +
+    '\n' +
+    'commit b894885ae467975226e81080a35625d247796960\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:13:25 2018 -0400\n' +
+    '\n' +
+    '    feat: Add moar features!\n';
+
+  const commits = [{message}];
+  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+
+  t.is(releaseType, 'patch');
+  t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'patch'));
+  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 1, 'patch'));
+});
+
+test('Treat modified squash merges with a BREAKING CHANGE as breaking', async t => {
+  const message =
+    'fix: This is only a fix.\n' +
+    '\n' +
+    'commit 06cfb67026eecec2ad54fd39fc50cba9080d383c\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:21:50 2018 -0400\n' +
+    '\n' +
+    '    fix: More fixes\n' +
+    '\n' +
+    '    Blah blah blah.\n' +
+    '\n' +
+    '    BREAKING CHANGE: Boom\n' +
+    '\n' +
+    'commit b894885ae467975226e81080a35625d247796960\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:13:25 2018 -0400\n' +
+    '\n' +
+    '    feat: Add moar features!\n';
+
+  const commits = [{message}];
+  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+
+  t.is(releaseType, 'major');
+  t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'major'));
+  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 1, 'major'));
+});
+
+test('Handle broken squash merge like a regular commit', async t => {
+  // This looks like a squash merge, but it's invalid because it doesn't
+  // follow the "commit, author, date, indentend body" pattern.
+  const message =
+    'Squashed commit of the following:\n' +
+    '\n' +
+    'commit 06cfb67026eecec2ad54fd39fc50cba9080d383c\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:21:50 2018 -0400\n' +
+    '\n' +
+    '    fix: More fixes\n' +
+    '\n' +
+    '    Blah blah blah.\n' +
+    '\n' +
+    '    Fixes #20\n' +
+    '\n' +
+    'commit b894885ae467975226e81080a35625d247796960\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n';
+
+  const commits = [{message}];
+  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+
+  t.is(releaseType, null);
+  t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
+  t.true(t.context.log.calledWith('The commit should not trigger a release'));
+  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 1, 'no'));
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -268,9 +268,9 @@ test('Correctly handle squash merges', async t => {
   const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
 
   t.is(releaseType, 'minor');
-  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[0]));
+  t.true(t.context.log.calledWith('Analyzing squashed commit: %s', splitCommits[0]));
   t.true(t.context.log.calledWith('The release type for the commit is %s', 'patch'));
-  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[1]));
+  t.true(t.context.log.calledWith('Analyzing squashed commit: %s', splitCommits[1]));
   t.true(t.context.log.calledWith('The release type for the commit is %s', 'minor'));
   t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'minor'));
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -20,6 +20,42 @@ test('Parse with "conventional-changelog-angular" by default', async t => {
   t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'minor'));
 });
 
+test('Correctly handle squash merges', async t => {
+  const message =
+    'Squashed commit of the following:\n' +
+    '\n' +
+    'commit 06cfb67026eecec2ad54fd39fc50cba9080d383c\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:21:50 2018 -0400\n' +
+    '\n' +
+    '    fix: More fixes\n' +
+    '\n' +
+    '    Blah blah blah.\n' +
+    '\n' +
+    '    Fixes #20\n' +
+    '\n' +
+    'commit b894885ae467975226e81080a35625d247796960\n' +
+    'Author: Jason Walton <fakeaddress@fake.com>\n' +
+    'Date:   Thu May 17 11:13:25 2018 -0400\n' +
+    '\n' +
+    '    feat: Add moar features!\n';
+
+  const splitCommits = [
+    'fix: More fixes\n\nBlah blah blah.\n\nFixes #20',
+    'feat: Add moar features!'
+  ];
+
+  const commits = [{message}];
+  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+
+  t.is(releaseType, 'minor');
+  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[0]));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'patch'));
+  t.true(t.context.log.calledWith('Analyzing commit: %s', splitCommits[1]));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'minor'));
+  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'minor'));
+});
+
 test('Accept "preset" option', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
   const releaseType = await commitAnalyzer({preset: 'eslint'}, {commits, logger: t.context.logger});


### PR DESCRIPTION
See discussion https://github.com/semantic-release/commit-analyzer/issues/65 and https://github.com/semantic-release/semantic-release/issues/792.

This makes it so commit-analyzer parses commit messages of the form:

```
Squashed commit of the following:

commit 74e6b0087331e5947fd8ba388e75d4d1900dfd44
Author: Jason Walton <dev@lucid.thedreaming.org>
Date:   Thu May 17 11:21:50 2018 -0400

    fix: More fixes

commit b894885ae467975226e81080a35625d247796960
Author: Jason Walton <dev@lucid.thedreaming.org>
Date:   Thu May 17 11:13:25 2018 -0400

    fix: Fix
```

as a collection of individual commits, rather than as a single commit message.  Note that in order to be broken up, the commit *must* start with the line "Squashed commit of the following:", and be followed by one or more "commit, author. date, indentented-body" groups.  If the commit does not follow this format exactly, then we'll treat the entire commit message as a single commit (exactly like it used to be).

* If you accidentally squash-merge a "feat" from github, this will now correctly produce a "minor" release instead of a "patch" release.
* Note that if you modify the first line (change it to "fix: blahblahblah", for example), then we'll treat the entire commit as a single commit, and use a "patch" release (unless "BREAKING CHANGE" appears anywhere in one of the child commits, and then we'll treat it as "major" - this is a bit sketchy, but is unchanged from current behavior.)  You can still edit squash merges to fix things, in fact...
* If you modify individual messages inside the squash merge, but leave the "Squashed commit of the following:" at the top, then we'll scan individual commits within the squash merge with your changes, allowing you fine grained control editing squash merges.

Note the log explicitly identifies commits that were parsed from a squash merge:

<img width="410" alt="screen shot 2018-05-18 at 7 54 13 am" src="https://user-images.githubusercontent.com/1771003/40233654-e76280b6-5a71-11e8-8fee-7ab5c42f8503.png">
