### PR TITLE
Handle revert commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const parser = require('conventional-commits-parser').sync;
+const filter = require('conventional-commits-filter');
 const debug = require('debug')('semantic-release:commit-analyzer');
 const loadParserConfig = require('./lib/load-parser-config');
 const loadReleaseRules = require('./lib/load-release-rules');
@@ -25,9 +26,10 @@ async function commitAnalyzer(pluginConfig, {commits, logger}) {
   const config = await loadParserConfig(pluginConfig);
   let releaseType = null;
 
-  commits.every(rawCommit => {
-    const commit = parser(rawCommit.message, config);
-    logger.log(`Analyzing commit: %s`, rawCommit.message);
+  filter(
+    commits.map(({message, ...commitProps}) => ({rawMsg: message, message, ...commitProps, ...parser(message, config)}))
+  ).every(({rawMsg, ...commit}) => {
+    logger.log(`Analyzing commit: %s`, rawMsg);
     let commitReleaseType;
 
     // Determine release type based on custom releaseRules

--- a/lib/analyze-commit.js
+++ b/lib/analyze-commit.js
@@ -15,9 +15,11 @@ module.exports = (releaseRules, commit) => {
 
   releaseRules
     .filter(
-      ({breaking, release, ...rule}) =>
+      ({breaking, revert, release, ...rule}) =>
         // If the rule is not `breaking` or the commit doesn't have a breaking change note
         (!breaking || (commit.notes && commit.notes.length > 0)) &&
+        // If the rule is not `revert` or the commit is not a revert
+        (!revert || commit.revert) &&
         // Otherwise match the regular rules
         isMatchWith(
           commit,

--- a/lib/analyze-commit.js
+++ b/lib/analyze-commit.js
@@ -1,4 +1,4 @@
-const {isMatchWith, isRegExp, omit} = require('lodash');
+const {isMatchWith, isRegExp} = require('lodash');
 const debug = require('debug')('semantic-release:commit-analyzer');
 const RELEASE_TYPES = require('./default-release-types');
 const compareReleaseTypes = require('./compare-release-types');
@@ -15,11 +15,13 @@ module.exports = (releaseRules, commit) => {
 
   releaseRules
     .filter(
-      rule =>
-        (!rule.breaking || (commit.notes && commit.notes.length > 0)) &&
+      ({breaking, release, ...rule}) =>
+        // If the rule is not `breaking` or the commit doesn't have a breaking change note
+        (!breaking || (commit.notes && commit.notes.length > 0)) &&
+        // Otherwise match the regular rules
         isMatchWith(
           commit,
-          omit(rule, ['release', 'breaking']),
+          rule,
           (obj, src) =>
             /^\/.*\/$/.test(src) || isRegExp(src) ? new RegExp(/^\/(.*)\/$/.exec(src)[1]).test(obj) : undefined
         )

--- a/lib/default-release-rules.js
+++ b/lib/default-release-rules.js
@@ -5,6 +5,7 @@
  */
 module.exports = [
   {breaking: true, release: 'major'},
+  {revert: true, release: 'patch'},
   // Angular
   {type: 'feat', release: 'minor'},
   {type: 'fix', release: 'patch'},

--- a/lib/load-parser-config.js
+++ b/lib/load-parser-config.js
@@ -1,6 +1,5 @@
 const {promisify} = require('util');
 const importFrom = require('import-from');
-const {mergeWith} = require('lodash');
 const conventionalChangelogAngular = require('conventional-changelog-angular');
 
 /**
@@ -29,9 +28,5 @@ module.exports = async ({preset, config, parserOpts}) => {
     loadedConfig = await loadedConfig;
   }
 
-  return mergeWith(
-    {},
-    !preset && !config && parserOpts ? parserOpts : {...loadedConfig.parserOpts, ...parserOpts},
-    (value, source) => (Array.isArray(value) ? source : undefined)
-  );
+  return !preset && !config && parserOpts ? parserOpts : {...loadedConfig.parserOpts, ...parserOpts};
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "conventional-changelog-angular": "^5.0.0",
+    "conventional-commits-filter": "^2.0.0",
     "conventional-commits-parser": "^3.0.0",
     "debug": "^3.1.0",
     "import-from": "^2.1.0",

--- a/test/analyze-commit.test.js
+++ b/test/analyze-commit.test.js
@@ -9,6 +9,14 @@ test('Match breaking change', t => {
   t.is(analyzeCommit([{breaking: true, release: 'major'}], commit), 'major');
 });
 
+test('Match revert commit', t => {
+  const commit = {
+    revert: {header: 'Update: First feature', hash: '123'},
+  };
+
+  t.is(analyzeCommit([{revert: true, release: 'patch'}], commit), 'patch');
+});
+
 test('Match multiple criteria with breaking change', t => {
   const commit = {
     type: 'feat',
@@ -16,6 +24,15 @@ test('Match multiple criteria with breaking change', t => {
   };
 
   t.is(analyzeCommit([{type: 'feat', breaking: true, release: 'major'}], commit), 'major');
+});
+
+test('Match multiple criteria with revert', t => {
+  const commit = {
+    type: 'feat',
+    revert: {header: 'Update: First feature', hash: '123'},
+  };
+
+  t.is(analyzeCommit([{type: 'feat', revert: true, release: 'major'}], commit), 'major');
 });
 
 test('Match multiple criteria', t => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -83,6 +83,20 @@ test('Accept a partial "parseOpts" object as option', async t => {
   t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 2, 'patch'));
 });
 
+test('Exclude commits if they have a matching revert commits', async t => {
+  const commits = [
+    {hash: '123', message: 'feat(scope): First feature'},
+    {hash: '456', message: 'revert: feat(scope): First feature\n\nThis reverts commit 123.\n'},
+    {message: 'fix(scope): First fix'},
+  ];
+  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+
+  t.is(releaseType, 'patch');
+  t.true(t.context.log.calledWith('Analyzing commit: %s', commits[2].message));
+  t.true(t.context.log.calledWith('The release type for the commit is %s', 'patch'));
+  t.true(t.context.log.calledWith('Analysis of %s commits complete: %s release', 3, 'patch'));
+});
+
 test('Accept a "releaseRules" option that reference a requierable module', async t => {
   const commits = [{message: 'fix(scope1): First fix'}, {message: 'feat(scope2): Second feature'}];
   const releaseType = await commitAnalyzer(


### PR DESCRIPTION
**feat: exclude commit from analysis if they have a matching revert commit**

If multiple commits are analyzed at the same time, and one revert another, they will be both ignored. As those commits do not change code within the group of analyzed commits they shouldn't trigger a release.


**feat: add release rule for revert commits**

If a revert commit is analyzed (without the reverted commit being part of the commit group) it will now trigger a `patch` release by default.