### PR TITLE
feat: use `cwd` and `env` options passed by core

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,19 +11,21 @@ const DEFAULT_RELEASE_RULES = require('./lib/default-release-rules');
 /**
  * Determine the type of release to create based on a list of commits.
  *
- * @param {Object} [pluginConfig={}] semantic-release configuration
+ * @param {Object} pluginConfig The plugin configuration.
  * @param {String} pluginConfig.preset conventional-changelog preset ('angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint')
- * @param {String} pluginConfig.config requierable npm package with a custom conventional-changelog preset
- * @param {String|Array} pluginConfig.releaseRules a string to load an external module or an `Array` of rules.
- * @param {Object} pluginConfig.parserOpts additional `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
- * @param {Object} options semantic-release options
- * @param {Array} options.commits array of commits
+ * @param {String} pluginConfig.config Requierable npm package with a custom conventional-changelog preset
+ * @param {String|Array} pluginConfig.releaseRules A `String` to load an external module or an `Array` of rules.
+ * @param {Object} pluginConfig.parserOpts Additional `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
+ * @param {Object} context The semantic-release context.
+ * @param {Array<Object>} context.commits The commits to analyze.
+ * @param {String} context.cwd The current working directory.
  *
  * @returns {String|null} the type of release to create based on the list of commits or `null` if no release has to be done.
  */
-async function commitAnalyzer(pluginConfig, {commits, logger}) {
-  const releaseRules = loadReleaseRules(pluginConfig);
-  const config = await loadParserConfig(pluginConfig);
+async function commitAnalyzer(pluginConfig, context) {
+  const {commits, logger} = context;
+  const releaseRules = loadReleaseRules(pluginConfig, context);
+  const config = await loadParserConfig(pluginConfig, context);
   let releaseType = null;
 
   filter(

--- a/lib/load-parser-config.js
+++ b/lib/load-parser-config.js
@@ -5,19 +5,22 @@ const conventionalChangelogAngular = require('conventional-changelog-angular');
 /**
  * Load `conventional-changelog-parser` options. Handle presets that return either a `Promise<Array>` or a `Promise<Function>`.
  *
- * @param {Object} preset conventional-changelog preset ('angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint')
- * @param {string} config requierable npm package with a custom conventional-changelog preset
- * @param {Object} parserOpts additionnal `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
+ * @param {Object} pluginConfig The plugin configuration.
+ * @param {Object} pluginConfig.preset conventional-changelog preset ('angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint')
+ * @param {String} pluginConfig.config Requierable npm package with a custom conventional-changelog preset
+ * @param {Object} pluginConfig.parserOpts Additionnal `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
+ * @param {Object} context The semantic-release context.
+ * @param {String} context.cwd The current working directory.
  * @return {Promise<Object>} a `Promise` that resolve to the `conventional-changelog-parser` options.
  */
-module.exports = async ({preset, config, parserOpts}) => {
+module.exports = async ({preset, config, parserOpts}, {cwd}) => {
   let loadedConfig;
 
   if (preset) {
     const presetPackage = `conventional-changelog-${preset.toLowerCase()}`;
-    loadedConfig = importFrom.silent(__dirname, presetPackage) || importFrom(process.cwd(), presetPackage);
+    loadedConfig = importFrom.silent(__dirname, presetPackage) || importFrom(cwd, presetPackage);
   } else if (config) {
-    loadedConfig = importFrom.silent(__dirname, config) || importFrom(process.cwd(), config);
+    loadedConfig = importFrom.silent(__dirname, config) || importFrom(cwd, config);
   } else {
     loadedConfig = conventionalChangelogAngular;
   }

--- a/lib/load-release-rules.js
+++ b/lib/load-release-rules.js
@@ -7,16 +7,20 @@ const RELEASE_TYPES = require('./default-release-types');
  * If `releaseRules` parameter is a `string` then load it as an external module with `require`.
  * Verifies that the loaded/parameter `releaseRules` is an `Array` and each element has a valid `release` attribute.
  *
- * @param {string|Array} releaseRules a string to load an external module or an `Array` of rules.
+ * @param {Object} pluginConfig The plugin configuration.
+ * @param {String|Array} pluginConfig.releaseRules A `String` to load an external module or an `Array` of rules.
+ * @param {Object} context The semantic-release context.
+ * @param {String} context.cwd The current working directory.
+ *
  * @return {Array} the loaded and validated `releaseRules`.
  */
-module.exports = ({releaseRules}) => {
+module.exports = ({releaseRules}, {cwd}) => {
   let loadedReleaseRules;
 
   if (releaseRules) {
     loadedReleaseRules =
       typeof releaseRules === 'string'
-        ? importFrom.silent(__dirname, releaseRules) || importFrom(process.cwd(), releaseRules)
+        ? importFrom.silent(__dirname, releaseRules) || importFrom(cwd, releaseRules)
         : releaseRules;
 
     if (!Array.isArray(loadedReleaseRules)) {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     ],
     "all": true
   },
+  "peerDependencies": {
+    "semantic-release": ">=15.8.0 <16.0.0"
+  },
   "prettier": {
     "printWidth": 120,
     "trailingComma": "es5"

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,6 +2,8 @@ import test from 'ava';
 import {stub} from 'sinon';
 import commitAnalyzer from '..';
 
+const cwd = process.cwd();
+
 test.beforeEach(t => {
   const log = stub();
   t.context.log = log;
@@ -10,7 +12,7 @@ test.beforeEach(t => {
 
 test('Parse with "conventional-changelog-angular" by default', async t => {
   const commits = [{message: 'fix(scope1): First fix'}, {message: 'feat(scope2): Second feature'}];
-  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'minor');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -22,7 +24,7 @@ test('Parse with "conventional-changelog-angular" by default', async t => {
 
 test('Accept "preset" option', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  const releaseType = await commitAnalyzer({preset: 'eslint'}, {commits, logger: t.context.logger});
+  const releaseType = await commitAnalyzer({preset: 'eslint'}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'minor');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -36,7 +38,7 @@ test('Accept "config" option', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
   const releaseType = await commitAnalyzer(
     {config: 'conventional-changelog-eslint'},
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -54,7 +56,7 @@ test('Accept a "parseOpts" object as option', async t => {
   ];
   const releaseType = await commitAnalyzer(
     {parserOpts: {headerPattern: /^%%(.*?)%% (.*)$/, headerCorrespondence: ['tag', 'shortDesc']}},
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -72,7 +74,7 @@ test('Accept a partial "parseOpts" object as option', async t => {
       config: 'conventional-changelog-eslint',
       parserOpts: {headerPattern: /^%%(.*?)%% (.*)$/, headerCorrespondence: ['type', 'shortDesc']},
     },
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'patch');
@@ -89,7 +91,7 @@ test('Exclude commits if they have a matching revert commits', async t => {
     {hash: '456', message: 'revert: feat(scope): First feature\n\nThis reverts commit 123.\n'},
     {message: 'fix(scope): First fix'},
   ];
-  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'patch');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[2].message));
@@ -101,7 +103,7 @@ test('Accept a "releaseRules" option that reference a requierable module', async
   const commits = [{message: 'fix(scope1): First fix'}, {message: 'feat(scope2): Second feature'}];
   const releaseType = await commitAnalyzer(
     {releaseRules: './test/fixtures/release-rules'},
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -117,7 +119,7 @@ test('Return "major" if there is a breaking change, using default releaseRules',
     {message: 'Fix: First fix (fixes #123)'},
     {message: 'Update: Second feature (fixes #456) \n\n BREAKING CHANGE: break something'},
   ];
-  const releaseType = await commitAnalyzer({preset: 'eslint'}, {commits, logger: t.context.logger});
+  const releaseType = await commitAnalyzer({preset: 'eslint'}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'major');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -129,7 +131,7 @@ test('Return "major" if there is a breaking change, using default releaseRules',
 
 test('Return "patch" if there is only types set to "patch", using default releaseRules', async t => {
   const commits = [{message: 'fix: First fix (fixes #123)'}, {message: 'perf: perf improvement'}];
-  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'patch');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -142,11 +144,8 @@ test('Return "patch" if there is only types set to "patch", using default releas
 test('Allow to use regex in "releaseRules" configuration', async t => {
   const commits = [{message: 'Chore: First chore (fixes #123)'}, {message: 'Docs: update README (fixes #456)'}];
   const releaseType = await commitAnalyzer(
-    {
-      preset: 'eslint',
-      releaseRules: [{tag: 'Chore', release: 'patch'}, {message: '/README/', release: 'minor'}],
-    },
-    {commits, logger: t.context.logger}
+    {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'patch'}, {message: '/README/', release: 'minor'}]},
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -159,7 +158,7 @@ test('Allow to use regex in "releaseRules" configuration', async t => {
 
 test('Return "null" if no rule match', async t => {
   const commits = [{message: 'doc: doc update'}, {message: 'chore: Chore'}];
-  const releaseType = await commitAnalyzer({}, {commits, logger: t.context.logger});
+  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, null);
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -173,7 +172,7 @@ test('Process rules in order and apply highest match', async t => {
   const commits = [{message: 'Chore: First chore (fixes #123)'}, {message: 'Docs: update README (fixes #456)'}];
   const releaseType = await commitAnalyzer(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'minor'}, {tag: 'Chore', release: 'patch'}]},
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -191,7 +190,7 @@ test('Process rules in order and apply highest match from config even if default
   ];
   const releaseType = await commitAnalyzer(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'patch'}, {breaking: true, release: 'minor'}]},
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -206,7 +205,7 @@ test('Use default "releaseRules" if none of provided match', async t => {
   const commits = [{message: 'Chore: First chore'}, {message: 'Update: new feature'}];
   const releaseType = await commitAnalyzer(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'patch'}]},
-    {commits, logger: t.context.logger}
+    {cwd, commits, logger: t.context.logger}
   );
 
   t.is(releaseType, 'minor');
@@ -218,40 +217,40 @@ test('Use default "releaseRules" if none of provided match', async t => {
 });
 
 test('Throw error if "preset" doesn`t exist', async t => {
-  const error = await t.throws(commitAnalyzer({preset: 'unknown-preset'}, {}));
+  const error = await t.throws(commitAnalyzer({preset: 'unknown-preset'}, {cwd}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });
 
 test('Throw error if "releaseRules" is not an Array or a String', async t => {
   await t.throws(
-    commitAnalyzer({releaseRules: {}}, {}),
+    commitAnalyzer({releaseRules: {}}, {cwd}),
     /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 });
 
 test('Throw error if "releaseRules" option reference a requierable module that is not an Array or a String', async t => {
   await t.throws(
-    commitAnalyzer({releaseRules: './test/fixtures/release-rules-invalid'}, {}),
+    commitAnalyzer({releaseRules: './test/fixtures/release-rules-invalid'}, {cwd}),
     /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 });
 
 test('Throw error if "config" doesn`t exist', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  const error = await t.throws(commitAnalyzer({config: 'unknown-config'}, {commits, logger: t.context.logger}));
+  const error = await t.throws(commitAnalyzer({config: 'unknown-config'}, {cwd, commits, logger: t.context.logger}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });
 
 test('Throw error if "releaseRules" reference invalid commit type', async t => {
   await t.throws(
-    commitAnalyzer({preset: 'eslint', releaseRules: [{tag: 'Update', release: 'invalid'}]}, {}),
+    commitAnalyzer({preset: 'eslint', releaseRules: [{tag: 'Update', release: 'invalid'}]}, {cwd}),
     /Error in commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
   );
 });
 
 test('Re-Throw error from "conventional-changelog-parser"', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  await t.throws(commitAnalyzer({parserOpts: {headerPattern: '\\'}}, {commits, logger: t.context.logger}));
+  await t.throws(commitAnalyzer({parserOpts: {headerPattern: '\\'}}, {cwd, commits, logger: t.context.logger}));
 });

--- a/test/load-parser-config.test.js
+++ b/test/load-parser-config.test.js
@@ -1,6 +1,8 @@
 import test from 'ava';
 import loadParserConfig from '../lib/load-parser-config';
 
+const cwd = process.cwd();
+
 /**
  * AVA macro to verify that `loadParserConfig` return a parserOpts object.
  *
@@ -9,7 +11,7 @@ import loadParserConfig from '../lib/load-parser-config';
  * @param {[type]} preset the `conventional-changelog` preset to test.
  */
 async function loadPreset(t, preset) {
-  t.truthy((await loadParserConfig({preset})).headerPattern);
+  t.truthy((await loadParserConfig({preset}, {cwd})).headerPattern);
 }
 loadPreset.title = (providedTitle, preset) => `${providedTitle} Load "${preset}" preset`.trim();
 
@@ -21,17 +23,17 @@ loadPreset.title = (providedTitle, preset) => `${providedTitle} Load "${preset}"
  * @param {[type]} config the `conventional-changelog` config to test.
  */
 async function loadConfig(t, config) {
-  t.truthy((await loadParserConfig({config: `conventional-changelog-${config}`})).headerPattern);
+  t.truthy((await loadParserConfig({config: `conventional-changelog-${config}`}, {cwd})).headerPattern);
 }
 loadConfig.title = (providedTitle, config) => `${providedTitle} Load "${config}" config`.trim();
 
 test('Load "conventional-changelog-angular" by default', async t => {
-  t.deepEqual(await loadParserConfig({}), (await require('conventional-changelog-angular')).parserOpts);
+  t.deepEqual(await loadParserConfig({}, {cwd}), (await require('conventional-changelog-angular')).parserOpts);
 });
 
 test('Accept a "parserOpts" object as option', async t => {
   const customParserOpts = {headerPattern: /^##(.*?)## (.*)$/, headerCorrespondence: ['tag', 'shortDesc']};
-  const parserOpts = await loadParserConfig({parserOpts: customParserOpts});
+  const parserOpts = await loadParserConfig({parserOpts: customParserOpts}, {cwd});
 
   t.is(customParserOpts.headerPattern, parserOpts.headerPattern);
   t.deepEqual(customParserOpts.headerCorrespondence, parserOpts.headerCorrespondence);
@@ -40,7 +42,7 @@ test('Accept a "parserOpts" object as option', async t => {
 
 test('Accept a partial "parserOpts" object as option that overlaod a preset', async t => {
   const customParserOpts = {headerPattern: /^##(.*?)## (.*)$/, headerCorrespondence: ['tag', 'shortDesc']};
-  const parserOpts = await loadParserConfig({parserOpts: customParserOpts, preset: 'angular'});
+  const parserOpts = await loadParserConfig({parserOpts: customParserOpts, preset: 'angular'}, {cwd});
 
   t.is(customParserOpts.headerPattern, parserOpts.headerPattern);
   t.deepEqual(customParserOpts.headerCorrespondence, parserOpts.headerCorrespondence);
@@ -49,7 +51,10 @@ test('Accept a partial "parserOpts" object as option that overlaod a preset', as
 
 test('Accept a partial "parserOpts" object as option that overlaod a config', async t => {
   const customParserOpts = {headerPattern: /^##(.*?)## (.*)$/, headerCorrespondence: ['tag', 'shortDesc']};
-  const parserOpts = await loadParserConfig({parserOpts: customParserOpts, config: 'conventional-changelog-angular'});
+  const parserOpts = await loadParserConfig(
+    {parserOpts: customParserOpts, config: 'conventional-changelog-angular'},
+    {cwd}
+  );
 
   t.is(customParserOpts.headerPattern, parserOpts.headerPattern);
   t.deepEqual(customParserOpts.headerCorrespondence, parserOpts.headerCorrespondence);
@@ -70,13 +75,13 @@ test(loadPreset, 'jshint');
 test(loadConfig, 'jshint');
 
 test('Throw error if "config" doesn`t exist', async t => {
-  const error = await t.throws(loadParserConfig({config: 'unknown-config'}));
+  const error = await t.throws(loadParserConfig({config: 'unknown-config'}, {cwd}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });
 
 test('Throw error if "preset" doesn`t exist', async t => {
-  const error = await t.throws(loadParserConfig({preset: 'unknown-preset'}));
+  const error = await t.throws(loadParserConfig({preset: 'unknown-preset'}, {cwd}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });

--- a/test/load-release-rules.test.js
+++ b/test/load-release-rules.test.js
@@ -2,55 +2,57 @@ import test from 'ava';
 import loadReleaseRules from '../lib/load-release-rules';
 import testReleaseRules from './fixtures/release-rules';
 
+const cwd = process.cwd();
+
 test('Accept a "releaseRules" option', t => {
-  const releaseRules = loadReleaseRules({releaseRules: testReleaseRules});
+  const releaseRules = loadReleaseRules({releaseRules: testReleaseRules}, {cwd});
 
   t.deepEqual(releaseRules, testReleaseRules);
 });
 
 test('Accept a "releaseRules" option that reference a requierable module', t => {
-  const releaseRules = loadReleaseRules({releaseRules: './test/fixtures/release-rules'});
+  const releaseRules = loadReleaseRules({releaseRules: './test/fixtures/release-rules'}, {cwd});
 
   t.deepEqual(releaseRules, testReleaseRules);
 });
 
 test('Return undefined if "releaseRules" not set', t => {
-  const releaseRules = loadReleaseRules({});
+  const releaseRules = loadReleaseRules({}, {cwd});
 
   t.is(releaseRules, undefined);
 });
 
 test('Throw error if "releaseRules" reference invalid commit type', t => {
   t.throws(
-    () => loadReleaseRules({releaseRules: [{tag: 'Update', release: 'invalid'}]}),
+    () => loadReleaseRules({releaseRules: [{tag: 'Update', release: 'invalid'}]}, {cwd}),
     /Error in commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
   );
 });
 
 test('Throw error if a rule in "releaseRules" does not have a release type', t => {
   t.throws(
-    () => loadReleaseRules({releaseRules: [{tag: 'Update'}]}),
+    () => loadReleaseRules({releaseRules: [{tag: 'Update'}]}, {cwd}),
     /Error in commit-analyzer configuration: rules must be an object with a "release" property/
   );
 });
 
 test('Throw error if "releaseRules" is not an Array or a String', t => {
   t.throws(
-    () => loadReleaseRules({releaseRules: {}}, {}),
+    () => loadReleaseRules({releaseRules: {}}, {cwd}),
     /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 });
 
 test('Throw error if "releaseRules" option reference a requierable module that is not an Array or a String', t => {
   t.throws(
-    () => loadReleaseRules({releaseRules: './test/fixtures/release-rules-invalid'}),
+    () => loadReleaseRules({releaseRules: './test/fixtures/release-rules-invalid'}, {cwd}),
     /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 });
 
 test('Throw error if "releaseRules" contains an undefined rule', t => {
   t.throws(
-    () => loadReleaseRules({releaseRules: [{type: 'feat', release: 'minor'}, undefined]}, {}),
+    () => loadReleaseRules({releaseRules: [{type: 'feat', release: 'minor'}, undefined]}, {cwd}),
     /Error in commit-analyzer configuration: rules must be an object with a "release" property/
   );
 });


### PR DESCRIPTION
BREAKING CHANGE: require `semantic-release` >= `15.8.0`