### PR TITLE
 fix: export as an object with `analyzeCommits` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **commit-analyzer**
 
-Customizable commit-analyzer plugin for [semantic-release](https://github.com/semantic-release/semantic-release) based on [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
+[**semantic-release**](https://github.com/semantic-release/semantic-release) plugin to analyze commits with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
 
 [![Travis](https://img.shields.io/travis/semantic-release/commit-analyzer.svg)](https://travis-ci.org/semantic-release/commit-analyzer)
 [![Codecov](https://img.shields.io/codecov/c/github/semantic-release/commit-analyzer.svg)](https://codecov.io/gh/semantic-release/commit-analyzer)
@@ -9,16 +9,24 @@ Customizable commit-analyzer plugin for [semantic-release](https://github.com/se
 [![npm latest version](https://img.shields.io/npm/v/@semantic-release/commit-analyzer/latest.svg)](https://www.npmjs.com/package/@semantic-release/commit-analyzer)
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/commit-analyzer/next.svg)](https://www.npmjs.com/package/@semantic-release/commit-analyzer)
 
-## Options
+| Step             | Description                                                                                                                                         |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `analyzeCommits` | Determine the type of release by analyzing commits with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog). |
 
-By default `commit-analyzer` uses the `angular` format described in [Angular convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular) and the [default rules](lib/default-release-rules.js) for release.
+## Install
 
-Additional options can be set within the plugin definition in `package.json` to use a different commit format and to customize it:
+```bash
+$ npm install @semantic-release/commit-analyzer -D
+```
+
+## Usage
+
+The plugin can be configured in the [**semantic-release** configuration file](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#configuration):
 
 ```json
 {
-  "release": {
-    "analyzeCommits": {
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
       "preset": "angular",
       "releaseRules": [
         {"type": "docs", "scope":"README", "release": "patch"},
@@ -28,65 +36,61 @@ Additional options can be set within the plugin definition in `package.json` to 
       "parserOpts": {
         "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
       }
-    }
-  }
+    }],
+    "@semantic-release/release-notes-generator"
+  ]
 }
 ```
 
-| Option         | Description                                                                                                                                                                                                                                                                                        | Default                             |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
-| `preset`       | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: `angular`, `atom`, `codemirror`, `ember`, `eslint`, `express`, `jquery`, `jscs`, `jshint`).                                                                                    | `angular`                           |
-| `config`       | NPM package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                    | -                                   |
-| `parserOpts`   | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends ones loaded by `preset` or `config`. See [Parser options](#parser-options). | -                                   |
-| `releaseRules` | An external module, a path to a module or an `Array` of rules. See [Release rules](#release-rules).                                                                                                                                                                                                | See [Release rules](#release-rules) |
+With this example:
+- the commits that contains `BREAKING CHANGE`, `BREAKING CHANGES` or `BREAKING` in their body will be considered breaking changes (by default the [angular preset](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L14) checks only for `BREAKING CHANGE` and `BREAKING CHANGES`)
+- the commits with a 'docs' `type`, a 'README' `scope` will be associated with a `patch` release
+- the commits with a 'refactor' `type` will be associated with a `patch` release
+- the commits with a 'style' `type` will be associated with a `patch` release
+
+## Configuration
+
+### Options
+
+| Option         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `preset`       | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular), [`atom`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-atom), [`codemirror`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-codemirror), [`ember`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-ember), [`eslint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint), [`express`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-express), [`jquery`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jquery), [`jshint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint)). | [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) |
+| `config`       | NPM package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                                                                                                                                 |
+| `parserOpts`   | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | -                                                                                                                                 |
+| `releaseRules` | An external module, a path to a module or an `Array` of rules. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | See [`releaseRules`](#releaserules)                                                                                               |
+
+**Notes**: in order to use a `preset` it must be installed (for example to use the [eslint preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint) you must install it with `npm install conventional-changelog-eslint -D`)
 
 **Note**: `config` will be overwritten by the values of `preset`. You should use either `preset` or `config`, but not both.
 
 **Note**: Individual properties of `parserOpts` will override ones loaded with an explicitly set `preset` or `config`. If `preset` or `config` are not set, only the properties set in `parserOpts` will be used.
 
-### Parser Options
-
-Allow to overwrite specific [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.
-
-The following example uses [Angular convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular) but will consider a commit to be a breaking change if [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser) detects a valid `BREAKING CHANGE`, `BREAKING CHANGES` or `BREAKING` section in the commit body. By default the [preset](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L14) checks only for `BREAKING CHANGE` and `BREAKING CHANGES`.
-
-```json
-{
-  "release": {
-    "analyzeCommits": {
-      "preset": "angular",
-      "parserOpts": {
-        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"],
-      }
-    }
-  }
-}
-```
-
-### Release Rules
+#### releaseRules
 
 Release rules are used when deciding if the commits since the last release warrant a new release. If you define custom release rules the default rules will be used if nothing matched. Those rules will be matched against the commit objects resulting of [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser) parsing.
 
 Release rules are used when deciding if the commits since the last release warrant a new release. If you define custom release rules the [default rules](lib/default-release-rules.js) will be used if nothing matched.
 
-#### Rules definition
+##### Rules definition
+
 This is an `Array` of rule objects. A rule object has a `release` property and 1 or more criteria.
 ```json
 {
-  "release": {
-    "analyzeCommits": {
+  "plugins": [
+    ["semantic-release/commit-analyzer", {
       "preset": "angular",
       "releaseRules": [
         {"type": "docs", "scope": "README", "release": "patch"},
         {"type": "refactor", "scope": "/core-.*/", "release": "minor"},
         {"type": "refactor", "release": "patch"}
       ]
-    }
-  }
+    }],
+    "@semantic-release/release-notes-generator"
+  ]
 }
 ```
 
-#### Rules matching
+##### Rules matching
 
 Each commit will be compared with each rule and when it matches, the commit will be associated with the release type in the rule's `release` property. If a commit match multiple rules, the highest release type (`major` > `minor` > `patch`) is associated with the commit.
 
@@ -97,7 +101,7 @@ With the previous example:
 - Commits with `type` 'refactor' and `scope` starting with 'core-' (i.e. 'core-ui', 'core-rules', ...) will be associated with a `minor` release.
 - Other commits with `type` 'refactor' (without `scope` or with a `scope` not matching the regexp `/core-.*/`) will be associated with a `patch` release.
 
-#### Default rules matching
+##### Default rules matching
 
 If a commit doesn't match any rule in `releaseRules` it will be evaluated against the [default release rules](lib/default-release-rules.js).
 
@@ -107,7 +111,7 @@ With the previous example:
 - Commits with `type` 'fix' will be associated with a `patch` release.
 - Commits with `type` 'perf' will be associated with a `patch` release.
 
-#### No rules matching
+##### No rules matching
 
 If a commit doesn't match any rules in `releaseRules` or in [default release rules](lib/default-release-rules.js) then no release type will be associated with the commit.
 
@@ -116,7 +120,7 @@ With the previous example:
 - Commits with `type` 'test' will not be associated with a release type.
 - Commits with `type` 'chore' will not be associated with a release type.
 
-#### Multiple commits
+##### Multiple commits
 
 If there is multiple commits that match one or more rules, the one with the highest release type will determine the global release type.
 
@@ -124,24 +128,25 @@ Considering the following commits:
 - `docs(README): Add more details to the API docs`
 - `feat(API): Add a new method to the public API`
 
-With the previous example the release type determine by the plugin will be `minor`.
+With the previous example the release type determined by the plugin will be `minor`.
 
-#### Specific commit properties
+##### Specific commit properties
 
 The properties to set in the rules will depends on the commit style chosen. For example [conventional-changelog-angular](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L9-L13) use the commit properties `type`, `scope` and `subject` but [conventional-changelog-eslint](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-eslint/index.js#L9-L12) uses `tag` and `message`.
 
 For example with `eslint` preset:
 ```json
 {
-  "release": {
-    "analyzeCommits": {
+  "plugins": [
+    ["semantic-release/commit-analyzer", {
       "preset": "eslint",
       "releaseRules": [
         {"tag": "Docs", "message":"/README/", "release": "patch"},
         {"type": "New", "release": "patch"}
       ]
-    }
-  }
+    }],
+    "@semantic-release/release-notes-generator"
+  ]
 }
 ```
 With this configuration:
@@ -153,17 +158,18 @@ With this configuration:
 - Commits with `tag` 'New' will be associated with a `minor` release (per [default release rules](lib/default-release-rules.js)).
 - All other commits will not be associated with a release type.
 
-#### External package / file
+##### External package / file
 
 `releaseRules` can also reference a module, either by it's `npm` name or path:
 ```json
 {
-  "release": {
-    "analyzeCommits": {
+  "plugins": [
+    ["semantic-release/commit-analyzer", {
       "preset": "angular",
       "releaseRules": "./config/release-rules.js"
-    }
-  }
+    }],
+    "@semantic-release/release-notes-generator"
+  ]
 }
 ```
 ```js
@@ -174,7 +180,3 @@ module.exports = [
   {type: 'refactor', release: 'patch'},
 ];
 ```
-
-## Usage
-
-The plugin is used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so installing it is not necessary and all configuration are optionals.

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const DEFAULT_RELEASE_RULES = require('./lib/default-release-rules');
  *
  * @returns {String|null} the type of release to create based on the list of commits or `null` if no release has to be done.
  */
-async function commitAnalyzer(pluginConfig, context) {
+async function analyzeCommits(pluginConfig, context) {
   const {commits, logger} = context;
   const releaseRules = loadReleaseRules(pluginConfig, context);
   const config = await loadParserConfig(pluginConfig, context);
@@ -68,4 +68,4 @@ async function commitAnalyzer(pluginConfig, context) {
   return releaseType;
 }
 
-module.exports = commitAnalyzer;
+module.exports = {analyzeCommits};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-release/commit-analyzer",
-  "description": "Customizable commit-analyzer plugin for semantic-release",
+  "description": "semantic-release plugin to analyze commits with conventional-changelog",
   "version": "0.0.0-development",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",
   "bugs": {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import {stub} from 'sinon';
-import commitAnalyzer from '..';
+import {analyzeCommits} from '..';
 
 const cwd = process.cwd();
 
@@ -12,7 +12,7 @@ test.beforeEach(t => {
 
 test('Parse with "conventional-changelog-angular" by default', async t => {
   const commits = [{message: 'fix(scope1): First fix'}, {message: 'feat(scope2): Second feature'}];
-  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
+  const releaseType = await analyzeCommits({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'minor');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -24,7 +24,7 @@ test('Parse with "conventional-changelog-angular" by default', async t => {
 
 test('Accept "preset" option', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  const releaseType = await commitAnalyzer({preset: 'eslint'}, {cwd, commits, logger: t.context.logger});
+  const releaseType = await analyzeCommits({preset: 'eslint'}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'minor');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -36,7 +36,7 @@ test('Accept "preset" option', async t => {
 
 test('Accept "config" option', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {config: 'conventional-changelog-eslint'},
     {cwd, commits, logger: t.context.logger}
   );
@@ -54,7 +54,7 @@ test('Accept a "parseOpts" object as option', async t => {
     {message: '%%BUGFIX%% First fix (fixes #123)'},
     {message: '%%FEATURE%% Second feature (fixes #456)'},
   ];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {parserOpts: {headerPattern: /^%%(.*?)%% (.*)$/, headerCorrespondence: ['tag', 'shortDesc']}},
     {cwd, commits, logger: t.context.logger}
   );
@@ -69,7 +69,7 @@ test('Accept a "parseOpts" object as option', async t => {
 
 test('Accept a partial "parseOpts" object as option', async t => {
   const commits = [{message: '%%fix%% First fix (fixes #123)'}, {message: '%%Update%% Second feature (fixes #456)'}];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {
       config: 'conventional-changelog-eslint',
       parserOpts: {headerPattern: /^%%(.*?)%% (.*)$/, headerCorrespondence: ['type', 'shortDesc']},
@@ -91,7 +91,7 @@ test('Exclude commits if they have a matching revert commits', async t => {
     {hash: '456', message: 'revert: feat(scope): First feature\n\nThis reverts commit 123.\n'},
     {message: 'fix(scope): First fix'},
   ];
-  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
+  const releaseType = await analyzeCommits({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'patch');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[2].message));
@@ -101,7 +101,7 @@ test('Exclude commits if they have a matching revert commits', async t => {
 
 test('Accept a "releaseRules" option that reference a requierable module', async t => {
   const commits = [{message: 'fix(scope1): First fix'}, {message: 'feat(scope2): Second feature'}];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {releaseRules: './test/fixtures/release-rules'},
     {cwd, commits, logger: t.context.logger}
   );
@@ -119,7 +119,7 @@ test('Return "major" if there is a breaking change, using default releaseRules',
     {message: 'Fix: First fix (fixes #123)'},
     {message: 'Update: Second feature (fixes #456) \n\n BREAKING CHANGE: break something'},
   ];
-  const releaseType = await commitAnalyzer({preset: 'eslint'}, {cwd, commits, logger: t.context.logger});
+  const releaseType = await analyzeCommits({preset: 'eslint'}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'major');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -131,7 +131,7 @@ test('Return "major" if there is a breaking change, using default releaseRules',
 
 test('Return "patch" if there is only types set to "patch", using default releaseRules', async t => {
   const commits = [{message: 'fix: First fix (fixes #123)'}, {message: 'perf: perf improvement'}];
-  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
+  const releaseType = await analyzeCommits({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, 'patch');
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -143,7 +143,7 @@ test('Return "patch" if there is only types set to "patch", using default releas
 
 test('Allow to use regex in "releaseRules" configuration', async t => {
   const commits = [{message: 'Chore: First chore (fixes #123)'}, {message: 'Docs: update README (fixes #456)'}];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'patch'}, {message: '/README/', release: 'minor'}]},
     {cwd, commits, logger: t.context.logger}
   );
@@ -158,7 +158,7 @@ test('Allow to use regex in "releaseRules" configuration', async t => {
 
 test('Return "null" if no rule match', async t => {
   const commits = [{message: 'doc: doc update'}, {message: 'chore: Chore'}];
-  const releaseType = await commitAnalyzer({}, {cwd, commits, logger: t.context.logger});
+  const releaseType = await analyzeCommits({}, {cwd, commits, logger: t.context.logger});
 
   t.is(releaseType, null);
   t.true(t.context.log.calledWith('Analyzing commit: %s', commits[0].message));
@@ -170,7 +170,7 @@ test('Return "null" if no rule match', async t => {
 
 test('Process rules in order and apply highest match', async t => {
   const commits = [{message: 'Chore: First chore (fixes #123)'}, {message: 'Docs: update README (fixes #456)'}];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'minor'}, {tag: 'Chore', release: 'patch'}]},
     {cwd, commits, logger: t.context.logger}
   );
@@ -188,7 +188,7 @@ test('Process rules in order and apply highest match from config even if default
     {message: 'Chore: First chore (fixes #123)'},
     {message: 'Docs: update README (fixes #456) \n\n BREAKING CHANGE: break something'},
   ];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'patch'}, {breaking: true, release: 'minor'}]},
     {cwd, commits, logger: t.context.logger}
   );
@@ -203,7 +203,7 @@ test('Process rules in order and apply highest match from config even if default
 
 test('Use default "releaseRules" if none of provided match', async t => {
   const commits = [{message: 'Chore: First chore'}, {message: 'Update: new feature'}];
-  const releaseType = await commitAnalyzer(
+  const releaseType = await analyzeCommits(
     {preset: 'eslint', releaseRules: [{tag: 'Chore', release: 'patch'}]},
     {cwd, commits, logger: t.context.logger}
   );
@@ -217,40 +217,40 @@ test('Use default "releaseRules" if none of provided match', async t => {
 });
 
 test('Throw error if "preset" doesn`t exist', async t => {
-  const error = await t.throws(commitAnalyzer({preset: 'unknown-preset'}, {cwd}));
+  const error = await t.throws(analyzeCommits({preset: 'unknown-preset'}, {cwd}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });
 
 test('Throw error if "releaseRules" is not an Array or a String', async t => {
   await t.throws(
-    commitAnalyzer({releaseRules: {}}, {cwd}),
+    analyzeCommits({releaseRules: {}}, {cwd}),
     /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 });
 
 test('Throw error if "releaseRules" option reference a requierable module that is not an Array or a String', async t => {
   await t.throws(
-    commitAnalyzer({releaseRules: './test/fixtures/release-rules-invalid'}, {cwd}),
+    analyzeCommits({releaseRules: './test/fixtures/release-rules-invalid'}, {cwd}),
     /Error in commit-analyzer configuration: "releaseRules" must be an array of rules/
   );
 });
 
 test('Throw error if "config" doesn`t exist', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  const error = await t.throws(commitAnalyzer({config: 'unknown-config'}, {cwd, commits, logger: t.context.logger}));
+  const error = await t.throws(analyzeCommits({config: 'unknown-config'}, {cwd, commits, logger: t.context.logger}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });
 
 test('Throw error if "releaseRules" reference invalid commit type', async t => {
   await t.throws(
-    commitAnalyzer({preset: 'eslint', releaseRules: [{tag: 'Update', release: 'invalid'}]}, {cwd}),
+    analyzeCommits({preset: 'eslint', releaseRules: [{tag: 'Update', release: 'invalid'}]}, {cwd}),
     /Error in commit-analyzer configuration: "invalid" is not a valid release type\. Valid values are:\[?.*\]/
   );
 });
 
 test('Re-Throw error from "conventional-changelog-parser"', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
-  await t.throws(commitAnalyzer({parserOpts: {headerPattern: '\\'}}, {cwd, commits, logger: t.context.logger}));
+  await t.throws(analyzeCommits({parserOpts: {headerPattern: '\\'}}, {cwd, commits, logger: t.context.logger}));
 });


### PR DESCRIPTION
child of semantic-release/semantic-release#936