### PR TITLE
Fixed the Typo in Configuration Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This is an `Array` of rule objects. A rule object has a `release` property and 1
 ```json
 {
   "plugins": [
-    ["semantic-release/commit-analyzer", {
+    ["@semantic-release/commit-analyzer", {
       "preset": "angular",
       "releaseRules": [
         {"type": "docs", "scope": "README", "release": "patch"},
@@ -136,7 +136,7 @@ For example with `eslint` preset:
 ```json
 {
   "plugins": [
-    ["semantic-release/commit-analyzer", {
+    ["@semantic-release/commit-analyzer", {
       "preset": "eslint",
       "releaseRules": [
         {"tag": "Docs", "message":"/README/", "release": "patch"},


### PR DESCRIPTION
Fixed the Typo in Configuration Object it should be *@semantic-release/commit-analyzer*