### PR TITLE
docs(README): Remove overridden release rule from eslint description

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ With this configuration:
 - Commits with `tag` 'Breaking' will be associated with a `major` release (per [default release rules](lib/default-release-rules.js)).
 - Commits with `tag` 'Fix' will be associated with a `patch` release (per [default release rules](lib/default-release-rules.js)).
 - Commits with `tag` 'Update' will be associated with a `minor` release (per [default release rules](lib/default-release-rules.js)).
-- Commits with `tag` 'New' will be associated with a `minor` release (per [default release rules](lib/default-release-rules.js)).
 - All other commits will not be associated with a release type.
 
 ##### External package / file


### PR DESCRIPTION
The documentation is incorrect here. The config in the example overrides the `New` tag and details around said tag are present twice.

Thanks for the work on this project.