### PR TITLE
Ignore default rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/commit-analyzer/next.svg)](https://www.npmjs.com/package/@semantic-release/commit-analyzer)
 
 | Step             | Description                                                                                                                                         |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `analyzeCommits` | Determine the type of release by analyzing commits with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog). |
 
 ## Install
@@ -26,23 +26,27 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 ```json
 {
   "plugins": [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
-      "releaseRules": [
-        {"type": "docs", "scope":"README", "release": "patch"},
-        {"type": "refactor", "release": "patch"},
-        {"type": "style", "release": "patch"}
-      ],
-      "parserOpts": {
-        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "docs", "scope": "README", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "style", "release": "patch" }
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+        }
       }
-    }],
+    ],
     "@semantic-release/release-notes-generator"
   ]
 }
 ```
 
 With this example:
+
 - the commits that contains `BREAKING CHANGE` or `BREAKING CHANGES` in their body will be considered breaking changes.
 - the commits with a 'docs' `type`, a 'README' `scope` will be associated with a `patch` release
 - the commits with a 'refactor' `type` will be associated with a `patch` release
@@ -54,12 +58,13 @@ With this example:
 
 ### Options
 
-| Option         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default                                                                                                                           |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `preset`       | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular), [`atom`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-atom), [`codemirror`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-codemirror), [`ember`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-ember), [`eslint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint), [`express`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-express), [`jquery`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jquery), [`jshint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint)). | [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) |
-| `config`       | npm package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                                                                                                                                 |
-| `parserOpts`   | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | -                                                                                                                                 |
-| `releaseRules` | An external module, a path to a module or an `Array` of rules. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | See [`releaseRules`](#releaserules)                                                                                               |
+| Option                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default                                                                                                                           |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `preset`                 | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular), [`atom`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-atom), [`codemirror`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-codemirror), [`ember`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-ember), [`eslint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint), [`express`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-express), [`jquery`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jquery), [`jshint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint)). | [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) |
+| `config`                 | npm package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                                                                                                                                 |
+| `parserOpts`             | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | -                                                                                                                                 |
+| `releaseRules`           | An external module, a path to a module or an `Array` of rules. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | See [`releaseRules`](#releaserules)                                                                                               |
+| `useDefaultReleaseRules` | Whether to use default release rules for non-matching `releaseRules`. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | See [`releaseRules`](#releaserules)                                                                                               |
 
 **Notes**: in order to use a `preset` it must be installed (for example to use the [eslint preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint) you must install it with `npm install conventional-changelog-eslint -D`)
 
@@ -74,17 +79,21 @@ Release rules are used when deciding if the commits since the last release warra
 ##### Rules definition
 
 This is an `Array` of rule objects. A rule object has a `release` property and 1 or more criteria.
+
 ```json
 {
   "plugins": [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
-      "releaseRules": [
-        {"type": "docs", "scope": "README", "release": "patch"},
-        {"type": "refactor", "scope": "/core-.*/", "release": "minor"},
-        {"type": "refactor", "release": "patch"}
-      ]
-    }],
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "docs", "scope": "README", "release": "patch" },
+          { "type": "refactor", "scope": "/core-.*/", "release": "minor" },
+          { "type": "refactor", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator"
   ]
 }
@@ -97,15 +106,17 @@ Each commit will be compared with each rule and when it matches, the commit will
 See [release types](lib/default-release-types.js) for the release types hierarchy.
 
 With the previous example:
+
 - Commits with `type` 'docs' and `scope` 'README' will be associated with a `patch` release.
 - Commits with `type` 'refactor' and `scope` starting with 'core-' (i.e. 'core-ui', 'core-rules', ...) will be associated with a `minor` release.
 - Other commits with `type` 'refactor' (without `scope` or with a `scope` not matching the regexp `/core-.*/`) will be associated with a `patch` release.
 
 ##### Default rules matching
 
-If a commit doesn't match any rule in `releaseRules` it will be evaluated against the [default release rules](lib/default-release-rules.js).
+If a commit doesn't match any rule in `releaseRules` it will be evaluated against the [default release rules](lib/default-release-rules.js). Set `useDefaultReleaseRules` to `false` to ignore this behavior.
 
 With the previous example:
+
 - Commits with a breaking change will be associated with a `major` release.
 - Commits with `type` 'feat' will be associated with a `minor` release.
 - Commits with `type` 'fix' will be associated with a `patch` release.
@@ -116,6 +127,7 @@ With the previous example:
 If a commit doesn't match any rules in `releaseRules` or in [default release rules](lib/default-release-rules.js) then no release type will be associated with the commit.
 
 With the previous example:
+
 - Commits with `type` 'style' will not be associated with a release type.
 - Commits with `type` 'test' will not be associated with a release type.
 - Commits with `type` 'chore' will not be associated with a release type.
@@ -125,6 +137,7 @@ With the previous example:
 If there is multiple commits that match one or more rules, the one with the highest release type will determine the global release type.
 
 Considering the following commits:
+
 - `docs(README): Add more details to the API docs`
 - `feat(API): Add a new method to the public API`
 
@@ -135,21 +148,27 @@ With the previous example the release type determined by the plugin will be `min
 The properties to set in the rules will depends on the commit style chosen. For example [conventional-changelog-angular](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular) use the commit properties `type`, `scope` and `subject` but [conventional-changelog-eslint](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-eslint) uses `tag` and `message`.
 
 For example with `eslint` preset:
+
 ```json
 {
   "plugins": [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "eslint",
-      "releaseRules": [
-        {"tag": "Docs", "message":"/README/", "release": "patch"},
-        {"tag": "New", "release": "patch"}
-      ]
-    }],
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "eslint",
+        "releaseRules": [
+          { "tag": "Docs", "message": "/README/", "release": "patch" },
+          { "tag": "New", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator"
   ]
 }
 ```
+
 With this configuration:
+
 - Commits with `tag` 'Docs', that contains 'README' in their header message will be associated with a `patch` release.
 - Commits with `tag` 'New' will be associated with a `patch` release.
 - Commits with `tag` 'Breaking' will be associated with a `major` release (per [default release rules](lib/default-release-rules.js)).
@@ -161,22 +180,27 @@ With this configuration:
 ##### External package / file
 
 `releaseRules` can also reference a module, either by it's `npm` name or path:
+
 ```json
 {
   "plugins": [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
-      "releaseRules": "./config/release-rules.js"
-    }],
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": "./config/release-rules.js"
+      }
+    ],
     "@semantic-release/release-notes-generator"
   ]
 }
 ```
+
 ```js
 // File: config/release-rules.js
 module.exports = [
-  {type: 'docs', scope: 'README', release: 'patch'},
-  {type: 'refactor', scope: /core-.*/, release: 'minor'},
-  {type: 'refactor', release: 'patch'},
+  { type: "docs", scope: "README", release: "patch" },
+  { type: "refactor", scope: /core-.*/, release: "minor" },
+  { type: "refactor", release: "patch" },
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/commit-analyzer/next.svg)](https://www.npmjs.com/package/@semantic-release/commit-analyzer)
 
 | Step             | Description                                                                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `analyzeCommits` | Determine the type of release by analyzing commits with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog). |
 
 ## Install
@@ -26,27 +26,23 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 ```json
 {
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "angular",
-        "releaseRules": [
-          { "type": "docs", "scope": "README", "release": "patch" },
-          { "type": "refactor", "release": "patch" },
-          { "type": "style", "release": "patch" }
-        ],
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
-        }
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "docs", "scope":"README", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "style", "release": "patch"}
+      ],
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
       }
-    ],
+    }],
     "@semantic-release/release-notes-generator"
   ]
 }
 ```
 
 With this example:
-
 - the commits that contains `BREAKING CHANGE` or `BREAKING CHANGES` in their body will be considered breaking changes.
 - the commits with a 'docs' `type`, a 'README' `scope` will be associated with a `patch` release
 - the commits with a 'refactor' `type` will be associated with a `patch` release
@@ -58,13 +54,13 @@ With this example:
 
 ### Options
 
-| Option                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default                                                                                                                           |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `preset`                 | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular), [`atom`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-atom), [`codemirror`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-codemirror), [`ember`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-ember), [`eslint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint), [`express`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-express), [`jquery`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jquery), [`jshint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint)). | [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) |
-| `config`                 | npm package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                                                                                                                                 |
-| `parserOpts`             | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | -                                                                                                                                 |
-| `releaseRules`           | An external module, a path to a module or an `Array` of rules. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | See [`releaseRules`](#releaserules)                                                                                               |
-| `useDefaultReleaseRules` | Whether to use default release rules for non-matching `releaseRules`. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | See [`releaseRules`](#releaserules)                                                                                               |
+| Option         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `preset`       | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular), [`atom`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-atom), [`codemirror`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-codemirror), [`ember`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-ember), [`eslint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint), [`express`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-express), [`jquery`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jquery), [`jshint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint)). | [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) |
+| `config`       | npm package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                                                                                                                                 |
+| `parserOpts`   | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | -                                                                                                                                 |
+| `releaseRules` | An external module, a path to a module or an `Array` of rules. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | See [`releaseRules`](#releaserules)                                                                                               |
+`useDefaultReleaseRules` | Whether to use default release rules for non-matching `releaseRules`. See [`releaseRules`](#releaserules).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | See [`releaseRules`](#releaserules)                                                                                               |
 
 **Notes**: in order to use a `preset` it must be installed (for example to use the [eslint preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint) you must install it with `npm install conventional-changelog-eslint -D`)
 
@@ -79,21 +75,17 @@ Release rules are used when deciding if the commits since the last release warra
 ##### Rules definition
 
 This is an `Array` of rule objects. A rule object has a `release` property and 1 or more criteria.
-
 ```json
 {
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "angular",
-        "releaseRules": [
-          { "type": "docs", "scope": "README", "release": "patch" },
-          { "type": "refactor", "scope": "/core-.*/", "release": "minor" },
-          { "type": "refactor", "release": "patch" }
-        ]
-      }
-    ],
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "docs", "scope": "README", "release": "patch"},
+        {"type": "refactor", "scope": "/core-.*/", "release": "minor"},
+        {"type": "refactor", "release": "patch"}
+      ]
+    }],
     "@semantic-release/release-notes-generator"
   ]
 }
@@ -106,7 +98,6 @@ Each commit will be compared with each rule and when it matches, the commit will
 See [release types](lib/default-release-types.js) for the release types hierarchy.
 
 With the previous example:
-
 - Commits with `type` 'docs' and `scope` 'README' will be associated with a `patch` release.
 - Commits with `type` 'refactor' and `scope` starting with 'core-' (i.e. 'core-ui', 'core-rules', ...) will be associated with a `minor` release.
 - Other commits with `type` 'refactor' (without `scope` or with a `scope` not matching the regexp `/core-.*/`) will be associated with a `patch` release.
@@ -116,7 +107,6 @@ With the previous example:
 If a commit doesn't match any rule in `releaseRules` it will be evaluated against the [default release rules](lib/default-release-rules.js). Set `useDefaultReleaseRules` to `false` to ignore this behavior.
 
 With the previous example:
-
 - Commits with a breaking change will be associated with a `major` release.
 - Commits with `type` 'feat' will be associated with a `minor` release.
 - Commits with `type` 'fix' will be associated with a `patch` release.
@@ -127,7 +117,6 @@ With the previous example:
 If a commit doesn't match any rules in `releaseRules` or in [default release rules](lib/default-release-rules.js) then no release type will be associated with the commit.
 
 With the previous example:
-
 - Commits with `type` 'style' will not be associated with a release type.
 - Commits with `type` 'test' will not be associated with a release type.
 - Commits with `type` 'chore' will not be associated with a release type.
@@ -137,7 +126,6 @@ With the previous example:
 If there is multiple commits that match one or more rules, the one with the highest release type will determine the global release type.
 
 Considering the following commits:
-
 - `docs(README): Add more details to the API docs`
 - `feat(API): Add a new method to the public API`
 
@@ -148,27 +136,21 @@ With the previous example the release type determined by the plugin will be `min
 The properties to set in the rules will depends on the commit style chosen. For example [conventional-changelog-angular](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular) use the commit properties `type`, `scope` and `subject` but [conventional-changelog-eslint](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-eslint) uses `tag` and `message`.
 
 For example with `eslint` preset:
-
 ```json
 {
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "eslint",
-        "releaseRules": [
-          { "tag": "Docs", "message": "/README/", "release": "patch" },
-          { "tag": "New", "release": "patch" }
-        ]
-      }
-    ],
+    ["@semantic-release/commit-analyzer", {
+      "preset": "eslint",
+      "releaseRules": [
+        {"tag": "Docs", "message":"/README/", "release": "patch"},
+        {"tag": "New", "release": "patch"}
+      ]
+    }],
     "@semantic-release/release-notes-generator"
   ]
 }
 ```
-
 With this configuration:
-
 - Commits with `tag` 'Docs', that contains 'README' in their header message will be associated with a `patch` release.
 - Commits with `tag` 'New' will be associated with a `patch` release.
 - Commits with `tag` 'Breaking' will be associated with a `major` release (per [default release rules](lib/default-release-rules.js)).
@@ -180,27 +162,22 @@ With this configuration:
 ##### External package / file
 
 `releaseRules` can also reference a module, either by it's `npm` name or path:
-
 ```json
 {
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "angular",
-        "releaseRules": "./config/release-rules.js"
-      }
-    ],
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "releaseRules": "./config/release-rules.js"
+    }],
     "@semantic-release/release-notes-generator"
   ]
 }
 ```
-
 ```js
 // File: config/release-rules.js
 module.exports = [
-  { type: "docs", scope: "README", release: "patch" },
-  { type: "refactor", scope: /core-.*/, release: "minor" },
-  { type: "refactor", release: "patch" },
+  {type: 'docs', scope: 'README', release: 'patch'},
+  {type: 'refactor', scope: /core-.*/, release: 'minor'},
+  {type: 'refactor', release: 'patch'},
 ];
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@semantic-release/commit-analyzer",
+  "name": "@condenast/commit-analyzer",
   "description": "semantic-release plugin to analyze commits with conventional-changelog",
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",
   "bugs": {
     "url": "https://github.com/semantic-release/commit-analyzer/issues"
@@ -90,7 +90,7 @@
     "cm": "git-cz",
     "codecov": "codecov -f coverage/coverage-final.json",
     "lint": "xo",
-    "pretest": "npm run lint",
+    "posttest": "npm run lint",
     "semantic-release": "semantic-release",
     "test": "nyc ava -v"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@condenast/commit-analyzer",
+  "name": "@semantic-release/commit-analyzer",
   "description": "semantic-release plugin to analyze commits with conventional-changelog",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",
   "bugs": {
     "url": "https://github.com/semantic-release/commit-analyzer/issues"
@@ -90,7 +90,7 @@
     "cm": "git-cz",
     "codecov": "codecov -f coverage/coverage-final.json",
     "lint": "xo",
-    "posttest": "npm run lint",
+    "pretest": "npm run lint",
     "semantic-release": "semantic-release",
     "test": "nyc ava -v"
   },

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -252,3 +252,19 @@ test('Re-Throw error from "conventional-changelog-parser"', async t => {
   const commits = [{message: 'Fix: First fix (fixes #123)'}, {message: 'Update: Second feature (fixes #456)'}];
   await t.throwsAsync(analyzeCommits({parserOpts: {headerPattern: '\\'}}, {cwd, commits, logger: t.context.logger}));
 });
+
+test('Does not use default "releaseRules" if "useDefaultReleaseRules" is false', async t => {
+  const commits = [{message: 'fix: First fix'}, {message: 'chore(README): Add stuff'}];
+
+  const releaseType = await analyzeCommits(
+    {preset: 'angular', useDefaultReleaseRules: false, releaseRules: [{scope: 'README', release: 'patch'}]},
+    {cwd, commits, logger: t.context.logger}
+  );
+
+  t.is(releaseType, 'patch');
+  t.true(t.context.log.getCall(0).calledWith('Analyzing commit: %s', commits[0].message));
+  t.true(t.context.log.getCall(1).calledWith('The commit should not trigger a release'));
+  t.true(t.context.log.getCall(2).calledWith('Analyzing commit: %s', commits[1].message));
+  t.true(t.context.log.getCall(3).calledWith('The release type for the commit is %s', 'patch'));
+  t.true(t.context.log.getCall(4).calledWith('Analysis of %s commits complete: %s release', 2, 'patch'));
+});


### PR DESCRIPTION
My goal is to set this plugin to match specific scopes. In other words, the commit analyzer should only match commits that look something like `fix(service/deps): Use express@4.3.2`. The plugin should not match a commit that looks like `fix(deps): Use express@4.3.2` or anything without a scope of `service*`. I'm using specific scopes because my particular use case is within a monorepo and certain packages should not be published if the commit is unrelated.

This work adds a `useDefaultReleaseRules` option, defaulting to `true` in order to maintain backwards compatibility. 

Issue Ref: https://github.com/semantic-release/commit-analyzer/issues/122