### PR TITLE
Add ability to specify custom release type `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ With the previous example:
 - Commits with `type` 'refactor' and `scope` starting with 'core-' (i.e. 'core-ui', 'core-rules', ...) will be associated with a `minor` release.
 - Other commits with `type` 'refactor' (without `scope` or with a `scope` not matching the regexp `/core-.*/`) will be associated with a `patch` release.
 
+##### Skipping release
+
+It is possible to use a `releaseRules` rule to skip releases of matching commits by setting the option `release: false`. For example, the following rule will skip releasing commits with the scope `norelease`:
+
+```json
+{
+  "releaseRules": [
+      {"scope": "norelease", "release": false}
+    ]
+}
+```
+
+The `false` release type is always the lowest release type, so if another commit matches some other rule, a release will still be created.
+
 ##### Default rules matching
 
 If a commit doesn't match any rule in `releaseRules` it will be evaluated against the [default release rules](lib/default-release-rules.js).

--- a/index.js
+++ b/index.js
@@ -36,15 +36,16 @@ async function analyzeCommits(pluginConfig, context) {
 
     // Determine release type based on custom releaseRules
     if (releaseRules) {
-      debug('Analyzing with custom rules');
       commitReleaseType = analyzeCommit(releaseRules, commit);
-      if (commitReleaseType) {
+      if (RELEASE_TYPES.indexOf(commitReleaseType) > 0) {
         logger.log('The release type for the commit is %s', commitReleaseType);
+      } else if (commitReleaseType === false) {
+        logger.log('The commit should not trigger a release');
       }
     }
 
     // If no custom releaseRules or none matched the commit, try with default releaseRules
-    if (!commitReleaseType) {
+    if (typeof commitReleaseType === 'undefined') {
       debug('Analyzing with default rules');
       commitReleaseType = analyzeCommit(DEFAULT_RELEASE_RULES, commit);
       if (commitReleaseType) {

--- a/lib/compare-release-types.js
+++ b/lib/compare-release-types.js
@@ -1,11 +1,13 @@
 const RELEASE_TYPES = require('./default-release-types');
 
 /**
- * Test if a realease type is of higher level than a given one.
+ * Test if a release type is of higher level than a given one.
  *
- * @param {string} currentReleaseType the current release type.
- * @param {string} releaseType the release type to compare with.
- * @return {Boolean} true if `releaseType` is higher than `currentReleaseType`.
+ * @param {String} currentReleaseType the current release type.
+ * @param {String|False} releaseType the release type to compare with.
+ * @return {Boolean} true when `releaseType` is higher than `currentReleaseType`, or if `currentReleaseType` is falsy, or if `releaseType`is `false`
  */
 module.exports = (currentReleaseType, releaseType) =>
-  !currentReleaseType || RELEASE_TYPES.indexOf(releaseType) < RELEASE_TYPES.indexOf(currentReleaseType);
+  !currentReleaseType ||
+  releaseType === false ||
+  RELEASE_TYPES.indexOf(releaseType) < RELEASE_TYPES.indexOf(currentReleaseType);

--- a/lib/load-release-rules.js
+++ b/lib/load-release-rules.js
@@ -28,9 +28,11 @@ module.exports = ({releaseRules}, {cwd}) => {
     }
 
     loadedReleaseRules.forEach(rule => {
-      if (!rule || !rule.release) {
-        throw new Error('Error in commit-analyzer configuration: rules must be an object with a "release" property');
-      } else if (RELEASE_TYPES.indexOf(rule.release) === -1) {
+      if (!rule || typeof rule.release === 'undefined') {
+        throw new Error(
+          'Error in commit-analyzer configuration: rules must be an object with a valid "release" property'
+        );
+      } else if (RELEASE_TYPES.indexOf(rule.release) === -1 && rule.release !== false) {
         throw new Error(
           `Error in commit-analyzer configuration: "${
             rule.release

--- a/test/compare-release-types.test.js
+++ b/test/compare-release-types.test.js
@@ -10,4 +10,8 @@ test('Compares release types', t => {
   t.false(compareReleaseTypes('major', 'minor'));
   t.false(compareReleaseTypes('major', 'patch'));
   t.false(compareReleaseTypes('minor', 'patch'));
+
+  t.true(compareReleaseTypes('major', false));
+  t.true(compareReleaseTypes('minor', false));
+  t.true(compareReleaseTypes('patch', false));
 });

--- a/test/fixtures/release-rules.js
+++ b/test/fixtures/release-rules.js
@@ -3,4 +3,5 @@ module.exports = [
   {type: 'feat', release: 'minor'},
   {type: 'fix', release: 'patch'},
   {type: 'perf', release: 'patch'},
+  {type: 'chore', release: false},
 ];

--- a/test/load-release-rules.test.js
+++ b/test/load-release-rules.test.js
@@ -32,7 +32,7 @@ test('Throw error if "releaseRules" reference invalid commit type', t => {
 test('Throw error if a rule in "releaseRules" does not have a release type', t => {
   t.throws(
     () => loadReleaseRules({releaseRules: [{tag: 'Update'}]}, {cwd}),
-    /Error in commit-analyzer configuration: rules must be an object with a "release" property/
+    /Error in commit-analyzer configuration: rules must be an object with a valid "release" property/
   );
 });
 
@@ -53,6 +53,6 @@ test('Throw error if "releaseRules" option reference a requierable module that i
 test('Throw error if "releaseRules" contains an undefined rule', t => {
   t.throws(
     () => loadReleaseRules({releaseRules: [{type: 'feat', release: 'minor'}, undefined]}, {cwd}),
-    /Error in commit-analyzer configuration: rules must be an object with a "release" property/
+    /Error in commit-analyzer configuration: rules must be an object with a valid "release" property/
   );
 });


### PR DESCRIPTION
This pull request adds the ability to specify a custom release rule that in effect skips the release for the given match:

```json
{
  "plugins": [
    ["@semantic-release/commit-analyzer", {
      "preset": "angular",
      "releaseRules": [
        {"scope": "storybook", "release": false}
      ]
    }],
    "@semantic-release/release-notes-generator"
  ]
}
```

Given the above configuration, any commits with the scope `storybook` will not create a release. If there are release-generating commits matching other rules, a release will still be created.

What are your thought on this functionality? I would personally use it, at least.

One thing I debated was whether mixing strings and `false` was good, but at least for the end-user it's pretty explicit, instead of for example using the string `"none"`.