### PR TITLE
chore: remove commitizen from our dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,6 @@
   "bugs": {
     "url": "https://github.com/semantic-release/commit-analyzer/issues"
   },
-  "config": {
-    "commitizen": {
-      "path": "cz-conventional-changelog"
-    }
-  },
   "contributors": [
     "Stephan Bönnemann <stephan@boennemann.me> (http://boennemann.me)",
     "Gregor Martynus (https://twitter.com/gr2m)"
@@ -34,14 +29,12 @@
   "devDependencies": {
     "ava": "^2.0.0",
     "codecov": "^3.0.0",
-    "commitizen": "^4.0.0",
     "conventional-changelog-atom": "^2.0.0",
     "conventional-changelog-conventionalcommits": "^4.1.0",
     "conventional-changelog-ember": "^2.0.0",
     "conventional-changelog-eslint": "^3.0.0",
     "conventional-changelog-express": "^2.0.0",
     "conventional-changelog-jshint": "^2.0.0",
-    "cz-conventional-changelog": "^2.0.0",
     "nyc": "^14.0.0",
     "rimraf": "^2.6.1",
     "semantic-release": "^15.0.0",
@@ -96,7 +89,6 @@
     "url": "https://github.com/semantic-release/commit-analyzer.git"
   },
   "scripts": {
-    "cm": "git-cz",
     "codecov": "codecov -f coverage/coverage-final.json",
     "lint": "xo",
     "pretest": "npm run lint",


### PR DESCRIPTION
Less dependencies to maintain.
Users who want to use Commitizen can use their own local install.