### PR TITLE
feat: support regex flags in release rules

### DIFF
--- a/lib/analyze-commit.js
+++ b/lib/analyze-commit.js
@@ -21,9 +21,19 @@ module.exports = (releaseRules, commit) => {
         // If the rule is not `revert` or the commit is not a revert
         (!revert || commit.revert) &&
         // Otherwise match the regular rules
-        isMatchWith(commit, rule, (obj, src) =>
-          /^\/.*\/$/.test(src) || isRegExp(src) ? new RegExp(/^\/(.*)\/$/.exec(src)[1]).test(obj) : undefined
-        )
+        isMatchWith(commit, rule, (obj, src) => {
+          if (isRegExp(src)) {
+            return src.test(obj);
+          }
+
+          const extractRegexFromString = /^\/(.*)\/([a-z]+)?$/;
+          if (extractRegexFromString.test(src)) {
+            const extracted = extractRegexFromString.exec(src);
+            return new RegExp(extracted[1], extracted[2]).test(obj);
+          }
+
+          return undefined;
+        })
     )
     .every(match => {
       if (compareReleaseTypes(releaseType, match.release)) {

--- a/test/analyze-commit.test.js
+++ b/test/analyze-commit.test.js
@@ -64,20 +64,28 @@ test('Return undefined if there is no match', t => {
 
 test('Match with regex', t => {
   const rules = [{type: 'docs', scope: /test\(.*\)/, release: 'minor'}];
+  const rulesWithRegexFlags = [{type: 'docs', scope: /test\(.*\)/i, release: 'minor'}];
   const match = {type: 'docs', scope: 'test(readme): message'};
   const notMatch = {type: 'docs', scope: 'test2(readme): message'};
 
   t.is(analyzeCommit(rules, match), 'minor');
   t.is(analyzeCommit(rules, notMatch), undefined);
+
+  t.is(analyzeCommit(rulesWithRegexFlags, match), 'minor');
+  t.is(analyzeCommit(rulesWithRegexFlags, notMatch), undefined);
 });
 
 test('Match with regex as string', t => {
   const rules = [{type: 'docs', scope: '/test\\(.*\\)/', release: 'minor'}];
+  const rulesWithRegexFlags = [{type: 'docs', scope: '/test\\(.*\\)/i', release: 'minor'}];
   const match = {type: 'docs', scope: 'test(readme): message'};
   const notMatch = {type: 'docs', scope: 'test2(readme): message'};
 
   t.is(analyzeCommit(rules, match), 'minor');
   t.is(analyzeCommit(rules, notMatch), undefined);
+
+  t.is(analyzeCommit(rulesWithRegexFlags, match), 'minor');
+  t.is(analyzeCommit(rulesWithRegexFlags, notMatch), undefined);
 });
 
 test('Return highest release type if multiple rules match', t => {


### PR DESCRIPTION
The current code breaks when a user includes flags in their regex (e.g. `/regex/i`).
This commit modifies the code so that:
- if the user passes in a regex, don't modify it
- if the user passes in a string that looks like a regex, also extract flags from it