### PR TITLE
feat: support improvement commit type

### DIFF
--- a/lib/default-release-rules.js
+++ b/lib/default-release-rules.js
@@ -16,6 +16,8 @@ module.exports = [
   {emoji: ':penguin:', release: 'patch'},
   {emoji: ':apple:', release: 'patch'},
   {emoji: ':checkered_flag:', release: 'patch'},
+  // Conventional
+  {type: 'improvement', release: 'minor'},
   // Ember
   {tag: 'BUGFIX', release: 'patch'},
   {tag: 'FEATURE', release: 'minor'},


### PR DESCRIPTION
This commit type is supported by `commitizen` via https://github.com/commitizen/conventional-commit-types/pull/13, though it's not officially part of the conventionalcommits spec as of `v1.0.0` (it was previously included in `v1.0.0-beta4`).

It'd be nice to find consensus on whether this type is valid under the conventionalcommits - feel free to push back on this changeset, and I can instead suggest a revert to https://github.com/commitizen/conventional-commit-types/pull/13.