### PR TITLE
chore: bump conventional commits parser to version 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "conventional-changelog-angular": "^5.0.0",
     "conventional-commits-filter": "^2.0.0",
-    "conventional-commits-parser": "^3.0.7",
+    "conventional-commits-parser": "^3.2.1",
     "debug": "^4.0.0",
     "import-from": "^3.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This version bump resolves #224 and therfore fixes an issue where commits without a proper header could not be analyzed