### PR TITLE
feat: allow catchall when analyzing commits

### DIFF
--- a/lib/analyze-commit.js
+++ b/lib/analyze-commit.js
@@ -22,9 +22,13 @@ module.exports = (releaseRules, commit) => {
         // If the rule is not `revert` or the commit is not a revert
         (!revert || commit.revert) &&
         // Otherwise match the regular rules
-        isMatchWith(commit, rule, (object, src) =>
-          isString(src) && isString(object) ? micromatch.isMatch(object, src) : undefined
-        )
+        isMatchWith(commit, rule, (object, src) => {
+          if (object === null && src === '*') {
+            return true;
+          }
+
+          return isString(src) && isString(object) ? micromatch.isMatch(object, src) : undefined;
+        })
     )
     .every((match) => {
       if (compareReleaseTypes(releaseType, match.release)) {

--- a/lib/analyze-commit.js
+++ b/lib/analyze-commit.js
@@ -23,7 +23,7 @@ module.exports = (releaseRules, commit) => {
         (!revert || commit.revert) &&
         // Otherwise match the regular rules
         isMatchWith(commit, rule, (object, src) => {
-          if (object === null && src === '*') {
+          if (src === '*') {
             return true;
           }
 

--- a/test/analyze-commit.test.js
+++ b/test/analyze-commit.test.js
@@ -85,6 +85,10 @@ test('Match with glob', (t) => {
   t.is(analyzeCommit(rules, notMatch), undefined);
 });
 
+test('Match with catchall and undefined commit', (t) => {
+  t.is(analyzeCommit([{type: '*', release: 'patch'}], {type: null}), 'patch');
+});
+
 test('Return highest release type if multiple rules match', (t) => {
   const commit = {
     type: 'feat',


### PR DESCRIPTION
This allows using a catchall to release any commits that don't match a rule. This is very useful for shared configurations when you are trying to migrate to semantic-release.

With the given configuration:
```json
{
  "type": "*",
  "release": "patch"
}
```

These two commit messages can now trigger a patch.

```text
newtype: here is a commit message
```

```text
here is a commit message that doesn't actually conform to spec
```

Let me know if there are changes or a better way to achieve this.