### PR TITLE
fix: "no release" is the lowest priority

### DIFF
--- a/lib/default-release-types.js
+++ b/lib/default-release-types.js
@@ -3,4 +3,4 @@
  *
  * @type {Array}
  */
-module.exports = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease'];
+module.exports = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease', false, null];


### PR DESCRIPTION
prior to this commit, using a custom analysis rule that set release to `false`, for example: 

```
[
    {type: 'fix', scope: 'frontend', release: 'patch'},
    {type: 'fix', scope: '*', release: false} // <----- this should NOT override 'patch'
]
```

would skip the release matching commits, even though another rule matches them with a higher release value. that is to say: this commit codifies `false` or `null` release values as the "lowest" release value, making it possible to treat "no release" the same way we treat all other release values, instead of treating it as a special exception. the primary use-case for this change is more granular control over commit analysis when using `scope`s

BREAKING CHANGE: `release: false` will not override other matching release rules of higher priority