### PR TITLE
fix: fix load-parser-config

### DIFF
--- a/lib/load-parser-config.js
+++ b/lib/load-parser-config.js
@@ -29,11 +29,13 @@ export default async ({ preset, config, parserOpts, presetConfig }, { cwd }) => 
     loadedConfig = conventionalChangelogAngular;
   }
 
-  loadedConfig = await (typeof loadedConfig === "function"
-    ? isPlainObject(presetConfig)
-      ? loadedConfig(presetConfig)
-      : promisify(loadedConfig)()
-    : loadedConfig);
+  if(typeof loadedConfig === "function") {
+    if(isPlainObject(presetConfig)) {
+      loadedConfig = isAsyncFunction(loadedConfig) ? await loadedConfig(presetConfig) : loadedConfig(presetConfig)
+    } else {
+      loadedConfig = isAsyncFunction(loadedConfig) ? await loadedConfig() : loadedConfig()
+    }
+  }
 
   return { ...loadedConfig.parserOpts, ...parserOpts };
 };


### PR DESCRIPTION
It appears that the current code does not work when the value of `loadedConfig` is an async function. 

After updating our project to use version 7 of `conventional-changelog-conventionalcommits`, semantic-release stopped working due to this bug because the preset results in an async function being assigned to `loadedConfig`. This patch allows for loadedConfig to also be an async function.