### PR TITLE
fix: cannot find module with package exports and support previous non-function configurations

### DIFF
--- a/lib/load-parser-config.js
+++ b/lib/load-parser-config.js
@@ -1,6 +1,6 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import importFrom from "import-from-esm";
+import importFrom from "import-from";
 import conventionalChangelogAngular from "conventional-changelog-angular";
 
 /**
@@ -21,11 +21,15 @@ export default async ({ preset, config, parserOpts, presetConfig }, { cwd }) => 
 
   if (preset) {
     const presetPackage = `conventional-changelog-${preset.toLowerCase()}`;
-    loadedConfig = await (
-      (await importFrom.silent(__dirname, presetPackage)) || (await importFrom(cwd, presetPackage))
-    )(presetConfig);
+    loadedConfig = await (importFrom.silent(__dirname, presetPackage) || importFrom(cwd, presetPackage));
+    if (typeof loadedConfig === "function") {
+      loadedConfig = await loadedConfig(presetConfig);
+    }
   } else if (config) {
-    loadedConfig = await ((await importFrom.silent(__dirname, config)) || (await importFrom(cwd, config)))();
+    loadedConfig = await (importFrom.silent(__dirname, config) || importFrom(cwd, config))();
+    if (typeof loadedConfig === "function") {
+      loadedConfig = await loadedConfig();
+    }
   } else {
     loadedConfig = await conventionalChangelogAngular();
   }

--- a/lib/load-release-rules.js
+++ b/lib/load-release-rules.js
@@ -1,7 +1,7 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isUndefined } from "lodash-es";
-import importFrom from "import-from-esm";
+import importFrom from "import-from";
 import RELEASE_TYPES from "./default-release-types.js";
 
 /**
@@ -24,7 +24,7 @@ export default async ({ releaseRules }, { cwd }) => {
   if (releaseRules) {
     loadedReleaseRules =
       typeof releaseRules === "string"
-        ? (await importFrom.silent(__dirname, releaseRules)) || (await importFrom(cwd, releaseRules))
+        ? importFrom.silent(__dirname, releaseRules) || importFrom(cwd, releaseRules)
         : releaseRules;
 
     if (!Array.isArray(loadedReleaseRules)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "conventional-commits-filter": "^4.0.0",
         "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
-        "import-from-esm": "^1.0.3",
+        "import-from": "^4.0.0",
         "lodash-es": "^4.17.21",
         "micromatch": "^4.0.2"
       },
@@ -26,6 +26,7 @@
         "conventional-changelog-eslint": "5.0.0",
         "conventional-changelog-express": "4.0.0",
         "conventional-changelog-jshint": "4.0.0",
+        "conventional-changelog-techor": "^2.5.24",
         "prettier": "3.2.4",
         "semantic-release": "23.0.0",
         "sinon": "17.0.1"
@@ -1485,6 +1486,17 @@
         "node": ">=16"
       }
     },
+    "node_modules/conventional-changelog-techor": {
+      "version": "2.5.24",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-techor/-/conventional-changelog-techor-2.5.24.tgz",
+      "integrity": "sha512-rTAfvZv+HEYtrRQPUJiZAw01LCwI4kQN7wzu9/C7Ep3KEk96WPngybOo3CQ+J8VJhMddk4basu1nqbi3WEgE2A==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "dedent": "^0.7.0",
+        "techor-conventional-commits": "^2.5.24"
+      }
+    },
     "node_modules/conventional-changelog-writer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
@@ -1662,6 +1674,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "dev": true
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -2485,10 +2503,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/import-from-esm": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
       "integrity": "sha512-U3Qt/CyfFpTUv6LOP2jRTLYjphH6zg3okMfHbyqRa/W2w6hr8OsJWVggNlR4jxuojQy81TgTJTxgSkyoteRGMQ==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
@@ -2501,6 +2531,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
       "integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7448,6 +7479,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/techor-conventional-commits": {
+      "version": "2.5.24",
+      "resolved": "https://registry.npmjs.org/techor-conventional-commits/-/techor-conventional-commits-2.5.24.tgz",
+      "integrity": "sha512-juW/+wdsb/nwXuw5kHdmJ9svsGF5p3kI5kPhb7eQ/PUFmSbWJGE/eUZAvPsj8xWE+8Sj0x8pws7ONBibC1coLg==",
+      "dev": true
     },
     "node_modules/temp-dir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "conventional-commits-filter": "^4.0.0",
     "conventional-commits-parser": "^5.0.0",
     "debug": "^4.0.0",
-    "import-from-esm": "^1.0.3",
+    "import-from": "^4.0.0",
     "lodash-es": "^4.17.21",
     "micromatch": "^4.0.2"
   },
@@ -34,6 +34,7 @@
     "conventional-changelog-eslint": "5.0.0",
     "conventional-changelog-express": "4.0.0",
     "conventional-changelog-jshint": "4.0.0",
+    "conventional-changelog-techor": "2.5.24",
     "prettier": "3.2.4",
     "semantic-release": "23.0.0",
     "sinon": "17.0.1"

--- a/test/presets.test.js
+++ b/test/presets.test.js
@@ -1,0 +1,21 @@
+import test from "ava";
+import { stub } from "sinon";
+import { analyzeCommits } from "../index.js";
+
+const cwd = process.cwd();
+
+test.beforeEach((t) => {
+  const log = stub();
+  t.context.log = log;
+  t.context.logger = { log };
+});
+
+test('Accept "preset" option', async (t) => {
+  const commits = [
+    { hash: "123", message: "Fix: First fix (fixes #123)" },
+    { hash: "456", message: "Update: Second feature (fixes #456)" },
+  ];
+  const releaseType = await analyzeCommits({ preset: "techor" }, { cwd, commits, logger: t.context.logger });
+
+  t.is(releaseType, null);
+});


### PR DESCRIPTION
- #537 
- https://github.com/semantic-release/semantic-release/issues/3130

Since upgrading to v11 we have lost these features:

- Force the configuration type to be a function
- `conventional-changelog-*` packages configured via objects are no longer supported

This is the version that Semantic Releases v23 has a mandatory dependency on. The side effects of supporting ESM presets outweigh the benefits.

Reproduction: https://github.com/1aron/techor/actions/runs/7667827891/job/20898475834