### PR TITLE
fix: import a package module with "exports" causing "Cannot not find module"

### DIFF
--- a/lib/load-parser-config.js
+++ b/lib/load-parser-config.js
@@ -1,6 +1,6 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import importFrom from "import-from-esm";
+import importFrom from "import-from";
 import conventionalChangelogAngular from "conventional-changelog-angular";
 
 /**

--- a/lib/load-release-rules.js
+++ b/lib/load-release-rules.js
@@ -1,7 +1,7 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isUndefined } from "lodash-es";
-import importFrom from "import-from-esm";
+import importFrom from "import-from";
 import RELEASE_TYPES from "./default-release-types.js";
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "conventional-commits-filter": "^4.0.0",
         "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
-        "import-from-esm": "^1.0.3",
+        "import-from": "^4.0.0",
         "lodash-es": "^4.17.21",
         "micromatch": "^4.0.2"
       },
@@ -2503,10 +2503,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/import-from-esm": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
       "integrity": "sha512-U3Qt/CyfFpTUv6LOP2jRTLYjphH6zg3okMfHbyqRa/W2w6hr8OsJWVggNlR4jxuojQy81TgTJTxgSkyoteRGMQ==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
@@ -2519,6 +2531,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
       "integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "conventional-changelog-eslint": "5.0.0",
         "conventional-changelog-express": "4.0.0",
         "conventional-changelog-jshint": "4.0.0",
+        "conventional-changelog-techor": "2.5.24",
         "prettier": "3.2.4",
         "semantic-release": "23.0.0",
         "sinon": "17.0.1"
@@ -1485,6 +1486,17 @@
         "node": ">=16"
       }
     },
+    "node_modules/conventional-changelog-techor": {
+      "version": "2.5.24",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-techor/-/conventional-changelog-techor-2.5.24.tgz",
+      "integrity": "sha512-rTAfvZv+HEYtrRQPUJiZAw01LCwI4kQN7wzu9/C7Ep3KEk96WPngybOo3CQ+J8VJhMddk4basu1nqbi3WEgE2A==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "dedent": "^0.7.0",
+        "techor-conventional-commits": "^2.5.24"
+      }
+    },
     "node_modules/conventional-changelog-writer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
@@ -1662,6 +1674,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "dev": true
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -7448,6 +7466,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/techor-conventional-commits": {
+      "version": "2.5.24",
+      "resolved": "https://registry.npmjs.org/techor-conventional-commits/-/techor-conventional-commits-2.5.24.tgz",
+      "integrity": "sha512-juW/+wdsb/nwXuw5kHdmJ9svsGF5p3kI5kPhb7eQ/PUFmSbWJGE/eUZAvPsj8xWE+8Sj0x8pws7ONBibC1coLg==",
+      "dev": true
     },
     "node_modules/temp-dir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "conventional-commits-filter": "^4.0.0",
     "conventional-commits-parser": "^5.0.0",
     "debug": "^4.0.0",
-    "import-from-esm": "^1.0.3",
+    "import-from": "^4.0.0",
     "lodash-es": "^4.17.21",
     "micromatch": "^4.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "conventional-changelog-eslint": "5.0.0",
     "conventional-changelog-express": "4.0.0",
     "conventional-changelog-jshint": "4.0.0",
+    "conventional-changelog-techor": "2.5.24",
     "prettier": "3.2.4",
     "semantic-release": "23.0.0",
     "sinon": "17.0.1"

--- a/test/load-parser-config.test.js
+++ b/test/load-parser-config.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import importFrom from "import-from-esm";
+import importFrom from "import-from";
 import sinon from "sinon";
 import loadParserConfig from "../lib/load-parser-config.js";
 
@@ -92,12 +92,13 @@ test(loadPreset, "express");
 test(loadConfig, "express");
 test(loadPreset, "jshint");
 test(loadConfig, "jshint");
-test(loadConfig, "techor");
 test(loadPreset, "conventionalcommits", { presetConfig: {} });
 test(loadConfig, "conventionalcommits", { presetConfig: {} });
 
-test('Throw error if "config" doesn`t exist', async (t) => {
-  await t.throwsAsync(loadParserConfig({ config: "unknown-config" }, { cwd }), { code: "MODULE_NOT_FOUND" });
+test('Throw error if "config" is not a function', async (t) => {
+  await t.throwsAsync(loadPreset(t, "techor"), {
+    message: "((intermediate value) || (intermediate value)) is not a function",
+  });
 });
 
 test('Throw error if "preset" doesn`t exist', async (t) => {

--- a/test/load-parser-config.test.js
+++ b/test/load-parser-config.test.js
@@ -92,6 +92,7 @@ test(loadPreset, "express");
 test(loadConfig, "express");
 test(loadPreset, "jshint");
 test(loadConfig, "jshint");
+test(loadConfig, "techor");
 test(loadPreset, "conventionalcommits", { presetConfig: {} });
 test(loadConfig, "conventionalcommits", { presetConfig: {} });
 


### PR DESCRIPTION
Fixed https://github.com/semantic-release/commit-analyzer/issues/589

I only did a few things:

- Changed `import-from-esm` back to `import-from` and passed **existing tests**.
- Added a package `conventional-changelog-techor` with "exports" section as a development test and added a related test.