### PR TITLE
feat: allow catchall for types when analyzing commits

### DIFF
--- a/lib/analyze-commit.js
+++ b/lib/analyze-commit.js
@@ -23,9 +23,13 @@ export default (releaseRules, commit) => {
         // If the rule is not `revert` or the commit is not a revert
         (!revert || commit.revert) &&
         // Otherwise match the regular rules
-        isMatchWith(commit, rule, (object, src) =>
-          isString(src) && isString(object) ? micromatch.isMatch(object, src) : undefined
-        )
+        isMatchWith(commit, rule, (object, src) => {
+          if (object === null && src === '*') {
+            return true;
+          }
+
+          return isString(src) && isString(object) ? micromatch.isMatch(object, src) : undefined;
+        })
     )
     .every((match) => {
       if (compareReleaseTypes(releaseType, match.release)) {

--- a/test/analyze-commit.test.js
+++ b/test/analyze-commit.test.js
@@ -85,6 +85,10 @@ test("Match with glob", (t) => {
   t.is(analyzeCommit(rules, notMatch), undefined);
 });
 
+test("Match with catchall and undefined commit", (t) => {
+  t.is(analyzeCommit([{type: '*', release: 'patch'}], {type: null}), 'patch');
+});
+
 test("Return highest release type if multiple rules match", (t) => {
   const commit = {
     type: "feat",


### PR DESCRIPTION
We would also be interested in https://github.com/semantic-release/commit-analyzer/pull/325, so I took the liberty to rebase the PR against main.