### PR TITLE
fix(deps): upgrade conventional changelog packages to latest major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "ls-engines": "0.9.4",
         "npm-run-all2": "9.0.3",
         "prettier": "3.9.6",
-        "publint": "0.3.22",
+        "publint": "0.3.23",
         "semantic-release": "25.0.8",
         "sinon": "22.1.0"
       },
@@ -10613,9 +10613,9 @@
       "license": "ISC"
     },
     "node_modules/publint": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.22.tgz",
-      "integrity": "sha512-6Z/scsr5CA7APdwyF35EY88CqgDj1textWuY788DVTJYPCWVv/Wn9G6KmLnrVRnStgYcahqN4wCDLZGSbQJ69w==",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.23.tgz",
+      "integrity": "sha512-5MQipUPcB7MWw84zLUkHrg/H/UBtk3LL+A0GngTTBSsiNJLQurMUaSIRG3edlOrRz4UFe0AOKK9TZdIWviV+jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "npm-run-all2": "9.0.3",
         "prettier": "3.9.6",
         "publint": "0.3.23",
-        "semantic-release": "25.0.8",
+        "semantic-release": "25.0.9",
         "sinon": "22.1.0"
       },
       "engines": {
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4267,9 +4267,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11151,9 +11151,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.8",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
-      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
+      "integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11327,16 +11327,16 @@
       }
     },
     "node_modules/semantic-release/node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "string-width": "^8.2.1",
         "y18n": "^5.0.5",
         "yargs-parser": "^22.0.0"
       },
@@ -11352,6 +11352,23 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver": {
@@ -12247,13 +12264,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "conventional-changelog-eslint": "6.1.0",
         "conventional-changelog-express": "5.1.0",
         "conventional-changelog-jshint": "5.2.0",
-        "lockfile-lint": "5.0.0",
+        "lockfile-lint": "5.0.1",
         "ls-engines": "0.9.4",
         "npm-run-all2": "9.0.3",
         "prettier": "3.9.6",
@@ -5741,16 +5741,16 @@
       }
     },
     "node_modules/lockfile-lint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-5.0.0.tgz",
-      "integrity": "sha512-QcVIVITLZAhWYHU2wbNSOMgwc6EN4Y2sy6mjgS5aikYyRzgDIfotXUsCrm38En+3fZpc58Yu7DF9dNeT/goi1A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-5.0.1.tgz",
+      "integrity": "sha512-Ukjf5yGBQwfl7L2niV3in7bU5wEww3+4Dkw89JGTzOuq18tzS7jaszl2oO7M6u+jcim080MfX5E4Gokt1KhRHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cosmiconfig": "^9.0.0",
         "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
         "lockfile-lint-api": "^5.9.2",
+        "tinyglobby": "^0.2.15",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^9.0.0",
-        "conventional-changelog-writer": "^8.0.0",
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
@@ -37,7 +36,7 @@
         "sinon": "22.1.0"
       },
       "engines": {
-        "node": "^22.14.0 || >= 24.10.0"
+        "node": "^22.22.2 || >=24.15"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
@@ -2949,6 +2948,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.1.0.tgz",
       "integrity": "sha512-dpC440QnORNCO81XYuRRFOLCsjKj4W7tMkUIn3lR6F/FAaJcWLi7iCj6IcEvSQY2zw6VUgwUKd5DEHKEWrpmEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "conventional-commits-filter": "^5.0.0",
@@ -4475,6 +4475,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -6430,6 +6431,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6686,6 +6688,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nerf-dart": {
@@ -11375,6 +11378,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11994,6 +11998,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13140,6 +13145,7 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -13525,6 +13531,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "conventional-changelog-conventionalcommits": "^9.0.0",
-        "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.0.0",
+        "conventional-changelog-conventionalcommits": "^10.0.0",
+        "conventional-commits-filter": "^6.0.0",
+        "conventional-commits-parser": "^7.0.0",
         "debug": "^4.0.0",
         "import-from-esm": "^2.0.0",
         "lodash-es": "^4.17.21",
@@ -20,9 +20,8 @@
       "devDependencies": {
         "ava": "6.4.1",
         "c8": "11.0.0",
-        "conventional-changelog-angular": "8.0.0",
+        "conventional-changelog-angular": "9.3.0",
         "conventional-changelog-atom": "5.1.0",
-        "conventional-changelog-conventionalcommits": "10.3.0",
         "conventional-changelog-ember": "5.1.0",
         "conventional-changelog-eslint": "6.1.0",
         "conventional-changelog-express": "5.1.0",
@@ -131,7 +130,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
       "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -953,6 +951,59 @@
         "semantic-release": ">=20.1.0"
       }
     },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@semantic-release/error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -1047,6 +1098,59 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
@@ -1256,6 +1360,18 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+      "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -1628,6 +1744,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
@@ -2866,16 +2994,16 @@
       "license": "ISC"
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
-      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.3.0.tgz",
+      "integrity": "sha512-0MWQLVUT1oVCsUGs9aAWteBVxPlLwJTn5VbQH7B0B3fDizZgrJ9QGnKl/2mp1+5P7153GCBCjO/v1aKJ6eysCg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-atom": {
@@ -2892,7 +3020,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
       "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@conventional-changelog/template": "^1.3.0"
@@ -2963,28 +3090,39 @@
         "node": ">=18"
       }
     },
-    "node_modules/conventional-commits-filter": {
+    "node_modules/conventional-changelog-writer/node_modules/conventional-commits-filter": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/conventional-commits-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.1.0.tgz",
-      "integrity": "sha512-5nxDo7TwKB5InYBl4ZC//1g9GRwB/F3TXOGR9hgUjMGfvSP4Vu5NkpNro2+1+TIEy1vwxApl5ircECr2ri5JIw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
       "license": "MIT",
       "dependencies": {
-        "meow": "^13.0.0"
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
       },
       "bin": {
         "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/convert-hrtime": {
@@ -6319,6 +6457,7 @@
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "c8": "11.0.0",
         "conventional-changelog-angular": "8.0.0",
         "conventional-changelog-atom": "5.1.0",
-        "conventional-changelog-conventionalcommits": "10.2.1",
+        "conventional-changelog-conventionalcommits": "10.3.0",
         "conventional-changelog-ember": "5.1.0",
         "conventional-changelog-eslint": "6.1.0",
         "conventional-changelog-express": "5.1.0",
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@conventional-changelog/template": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
-      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
+      "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2890,13 +2890,13 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
+      "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "@conventional-changelog/template": "^1.3.0"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "conventional-changelog-eslint": "6.1.0",
     "conventional-changelog-express": "5.1.0",
     "conventional-changelog-jshint": "5.2.0",
-    "lockfile-lint": "5.0.0",
+    "lockfile-lint": "5.0.1",
     "ls-engines": "0.9.4",
     "npm-run-all2": "9.0.3",
     "prettier": "3.9.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "dependencies": {
     "conventional-changelog-conventionalcommits": "^9.0.0",
-    "conventional-changelog-writer": "^8.0.0",
     "conventional-commits-filter": "^5.0.0",
     "conventional-commits-parser": "^6.0.0",
     "debug": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ls-engines": "0.9.4",
     "npm-run-all2": "9.0.3",
     "prettier": "3.9.6",
-    "publint": "0.3.22",
+    "publint": "0.3.23",
     "semantic-release": "25.0.8",
     "sinon": "22.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "Matt Travi <npm@travi.org> (https://matt.travi.org/)"
   ],
   "dependencies": {
-    "conventional-changelog-conventionalcommits": "^9.0.0",
-    "conventional-commits-filter": "^5.0.0",
-    "conventional-commits-parser": "^6.0.0",
+    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-commits-filter": "^6.0.0",
+    "conventional-commits-parser": "^7.0.0",
     "debug": "^4.0.0",
     "import-from-esm": "^2.0.0",
     "lodash-es": "^4.17.21",
@@ -30,9 +30,8 @@
   "devDependencies": {
     "ava": "6.4.1",
     "c8": "11.0.0",
-    "conventional-changelog-angular": "8.0.0",
+    "conventional-changelog-angular": "9.3.0",
     "conventional-changelog-atom": "5.1.0",
-    "conventional-changelog-conventionalcommits": "10.3.0",
     "conventional-changelog-ember": "5.1.0",
     "conventional-changelog-eslint": "6.1.0",
     "conventional-changelog-express": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "c8": "11.0.0",
     "conventional-changelog-angular": "8.0.0",
     "conventional-changelog-atom": "5.1.0",
-    "conventional-changelog-conventionalcommits": "10.2.1",
+    "conventional-changelog-conventionalcommits": "10.3.0",
     "conventional-changelog-ember": "5.1.0",
     "conventional-changelog-eslint": "6.1.0",
     "conventional-changelog-express": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npm-run-all2": "9.0.3",
     "prettier": "3.9.6",
     "publint": "0.3.23",
-    "semantic-release": "25.0.8",
+    "semantic-release": "25.0.9",
     "sinon": "22.1.0"
   },
   "engines": {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -64,7 +64,7 @@ test('Accept a "parseOpts" object as option', async (t) => {
     { hash: "456", message: "%%FEATURE%% Second feature (fixes #456)" },
   ];
   const releaseType = await analyzeCommits(
-    { parserOpts: { headerPattern: /^%%(?<type>.*?)%% (?<subject>.*)$/, headerCorrespondence: ["tag", "shortDesc"] } },
+    { parserOpts: { headerPattern: /^%%(.*?)%% (.*)$/, headerCorrespondence: ["tag", "shortDesc"] } },
     { cwd, commits, logger: t.context.logger }
   );
 
@@ -132,7 +132,7 @@ test('Accept a "releaseRules" option that reference a requirable module', async 
 test('Return "major" if there is a breaking change, using default releaseRules', async (t) => {
   const commits = [
     { hash: "123", message: "Fix: First fix (fixes #123)" },
-    { hash: "456", message: "Update: Second feature (fixes #456) \n\n BREAKING CHANGE: break something" },
+    { hash: "456", message: "Update: Second feature (fixes #456) \n\nBREAKING CHANGE: break something" },
   ];
   const releaseType = await analyzeCommits({ preset: "eslint" }, { cwd, commits, logger: t.context.logger });
 
@@ -240,7 +240,7 @@ test("Process rules in order and apply highest match", async (t) => {
 test("Process rules in order and apply highest match from config even if default has an higher match", async (t) => {
   const commits = [
     { hash: "123", message: "Chore: First chore (fixes #123)" },
-    { hash: "456", message: "Docs: update README (fixes #456) \n\n BREAKING CHANGE: break something" },
+    { hash: "456", message: "Docs: update README (fixes #456) \n\nBREAKING CHANGE: break something" },
   ];
   const releaseType = await analyzeCommits(
     {


### PR DESCRIPTION
This pull request primarily updates dependencies with focus on maintaining compatibility and improving reliability by using newer conventional changelog package versions.

**Dependency updates:**

* Updated several dependencies to their latest major versions, including `conventional-changelog-conventionalcommits`, `conventional-commits-filter`, and `conventional-commits-parser`
* Updated development dependencies such as `conventional-changelog-angular`.
* Removed unused `conventional-changelog-writer` dependency

**Test adjustments:**

* Simplified the regular expression for the `headerPattern` in the `parseOpts` test case by removing named capture groups, likely for compatibility with the updated parser.

## Related Issue

- Fixes #921
- Closes #914 
- Closes #915
- Closes #916  
- Closes #917

BREAKING CHANGE: From `conventional-changelog-parser@v7`, footer notes must start at the beginning of a line, a leading space now defeats note detection.

BREAKING CHANGE:  From `conventional-changelog-parser@v7`, named capture groups in `headerPattern` now take precedence over `headerCorrespondence`. In v6 the correspondence array won, in v7 the named groups win and the correspondence keys come back `null`.